### PR TITLE
Fix traefik ingress

### DIFF
--- a/addons/traefik-ui.yaml
+++ b/addons/traefik-ui.yaml
@@ -17,12 +17,15 @@ kind: Ingress
 metadata:
   name: traefik-web-ui
   namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    ingress.kubernetes.io/secure-backends: "true"
+    traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
-  - host: traefik-ui.minikube
-    http:
+  - http:
       paths:
-      - path: /
+      - path: /traefik-web-ui
         backend:
           serviceName: traefik-web-ui
-          servicePort: web
+          servicePort: "web"


### PR DESCRIPTION
This PR removes a minikube host from traefik ingress and adds a path-based rule:

![image](https://user-images.githubusercontent.com/52448429/60789000-b3fdc680-a166-11e9-9914-feaa973ba437.png)
