### PR TITLE
Fix api ingress name

### DIFF
--- a/addons/api-ingress.yaml
+++ b/addons/api-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: kubernetes-dashboard
+  name: kubernetes-api
   namespace: default
   annotations:
     kubernetes.io/ingress.class: traefik


### PR DESCRIPTION
Better to use kubernetes-api name since it's confusing to have 2 ingress with the same name in different namespaces