### PR TITLE
Send email when enabling and disabling remote API

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -373,7 +373,7 @@ addons:
       - setup-remote-api: ${this.api}
       - if (${this.api:true}):
           - setGlobals:
-              apiStatusMessage: enabled
+              apiStatusMessage: enabled at ${env.url}api
       - else:
           - setGlobals:
               apiStatusMessage: disabled
@@ -384,7 +384,7 @@ addons:
           <!DOCTYPE html>
             <html>
             <body>
-          Remote API has been ${globals.apiStatusMessage} at ${env.url}api
+          Remote API has been ${globals.apiStatusMessage}
             </body>
             </html>
 

--- a/manifest.jps
+++ b/manifest.jps
@@ -371,6 +371,22 @@ addons:
       addon-remote-api:
       - log: '${this.api}'
       - setup-remote-api: ${this.api}
+      - if (${this.api:true}):
+          - setGlobals:
+              apiStatusMessage: enabled
+      - else:
+          - setGlobals:
+              apiStatusMessage: disabled
+      - jelastic.message.email.SendToUser:
+        login: "${user.email}"
+        subject: Remote API ${globals.apiStatusMessage} in Kubernetes Cluster ${env.name}
+        body: |-
+          <!DOCTYPE html>
+            <html>
+            <body>
+          Remote API has been ${globals.apiStatusMessage} at ${env.url}api
+            </body>
+            </html>
 
 success: |
   ${globals.default_success:}


### PR DESCRIPTION
Just a small addition to manifest to make sure email is sent when remote API is enabled/disabled