### PR TITLE
Use tag for traefik daemon set

### DIFF
--- a/addons/traefik/traefik-ds.yaml
+++ b/addons/traefik/traefik-ds.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: traefik-ingress-controller
       terminationGracePeriodSeconds: 60
       containers:
-      - image: traefik
+      - image: traefik:v1.7.15
         name: traefik-ingress-lb
         ports:
         - name: http


### PR DESCRIPTION
Latest tag is being used now. Traefik folks have updated latest tag and all of the flags turned out to be unsupported:

![image](https://user-images.githubusercontent.com/52448429/65131533-0d586080-da08-11e9-86db-4bd03b0e21ea.png)

I tried to eliminate them one by one, with no success.

`v1.7.15` works fine (it seems to be the preceding tag before 2.0 release)