### PR TITLE
K8S-529 (fix uninstall add-on during upgrade)

### DIFF
--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -273,7 +273,7 @@ actions:
                     jps = buildAddon(jps, newJps);
                     delete newAddons[app.app_id];
                 } else {
-                    resp = api.marketplace.jps.Uninstall(appid, session, app.uniqueName);
+                    resp = api.marketplace.jps.Uninstall({ appUniqueName: app.uniqueName, force: true });
                     if (resp.result != 0) return resp;
                 }
             }


### PR DESCRIPTION
K8S-529 [K8s]: Cluster upgrade fails from 1.18.10 to 1.20.4