### PR TITLE
K8S-817: Update K8s version 1.29.9 -> 1.29.14

### DIFF
--- a/addons/ingress/haproxy/api-ingress.yaml
+++ b/addons/ingress/haproxy/api-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /api
         pathType: Prefix

--- a/addons/ingress/haproxy/dashboard-ingress.yaml
+++ b/addons/ingress/haproxy/dashboard-ingress.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard
         pathType: Prefix

--- a/addons/ingress/haproxy/helloworld-ingress.yaml
+++ b/addons/ingress/haproxy/helloworld-ingress.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /
         pathType: Prefix

--- a/addons/ingress/haproxy/jaeger-ingress.yaml
+++ b/addons/ingress/haproxy/jaeger-ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   name: jaeger
   namespace: observability
 spec:
+  ingress:
+    hosts:
+      - example.com
+    ingressClassName: haproxy
   allInOne:
     options:
       query:

--- a/addons/ingress/haproxy/skooner-ingress.yaml
+++ b/addons/ingress/haproxy/skooner-ingress.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard
         pathType: Prefix

--- a/addons/ingress/nginx/api-ingress.yaml
+++ b/addons/ingress/nginx/api-ingress.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /api(/|$)(.*)
         pathType: ImplementationSpecific

--- a/addons/ingress/nginx/dashboard-ingress.yaml
+++ b/addons/ingress/nginx/dashboard-ingress.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard(/|$)(.*)
         pathType: ImplementationSpecific

--- a/addons/ingress/nginx/helloworld-ingress.yaml
+++ b/addons/ingress/nginx/helloworld-ingress.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /
         pathType: Prefix

--- a/addons/ingress/nginx/jaeger-ingress.yaml
+++ b/addons/ingress/nginx/jaeger-ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   name: jaeger
   namespace: observability
 spec:
+  ingress:
+    hosts:
+      - example.com
+    ingressClassName: nginx
   allInOne:
     options:
       query:

--- a/addons/ingress/nginx/skooner-ingress.yaml
+++ b/addons/ingress/nginx/skooner-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard(/|$)(.*)
         pathType: ImplementationSpecific

--- a/addons/ingress/traefik/api-ingress.yaml
+++ b/addons/ingress/traefik/api-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /api
         pathType: Prefix

--- a/addons/ingress/traefik/dashboard-ingress.yaml
+++ b/addons/ingress/traefik/dashboard-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard
         pathType: Prefix

--- a/addons/ingress/traefik/helloworld-ingress.yaml
+++ b/addons/ingress/traefik/helloworld-ingress.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /
         pathType: Prefix

--- a/addons/ingress/traefik/jaeger-ingress.yaml
+++ b/addons/ingress/traefik/jaeger-ingress.yaml
@@ -5,6 +5,10 @@ metadata:
   name: jaeger
   namespace: observability
 spec:
+  ingress:
+    hosts:
+      - example.com
+    ingressClassName: traefik
   allInOne:
     options:
       query:

--- a/addons/ingress/traefik/skooner-ingress.yaml
+++ b/addons/ingress/traefik/skooner-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /kubernetes-dashboard
         pathType: Prefix

--- a/addons/monitoring/haproxy/alert-ingress.yaml
+++ b/addons/monitoring/haproxy/alert-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus-alert
         pathType: Prefix

--- a/addons/monitoring/haproxy/grafana-ingress.yaml
+++ b/addons/monitoring/haproxy/grafana-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /grafana
         pathType: Prefix

--- a/addons/monitoring/haproxy/prometheus-ingress.yaml
+++ b/addons/monitoring/haproxy/prometheus-ingress.yaml
@@ -7,11 +7,12 @@ metadata:
   annotations:
     haproxy.org/auth-type: basic-auth
     haproxy.org/auth-secret: monitoring-prometheus
-    haproxy.org/path-rewrite: /prometheus-alert(/|$)(.*) /\2
+    haproxy.org/path-rewrite: /prometheus(/|$)(.*) /\2
 spec:
-  ingressClassName: nginx
+  ingressClassName: haproxy
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus
         pathType: Prefix

--- a/addons/monitoring/nginx/alert-ingress.yaml
+++ b/addons/monitoring/nginx/alert-ingress.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus-alert(/|$)(.*)
         pathType: ImplementationSpecific

--- a/addons/monitoring/nginx/grafana-ingress.yaml
+++ b/addons/monitoring/nginx/grafana-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /grafana(/|$)(.*)
         pathType: ImplementationSpecific

--- a/addons/monitoring/nginx/prometheus-ingress.yaml
+++ b/addons/monitoring/nginx/prometheus-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus
         pathType: Prefix

--- a/addons/monitoring/traefik/alert-ingress.yaml
+++ b/addons/monitoring/traefik/alert-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus-alert
         pathType: Prefix

--- a/addons/monitoring/traefik/grafana-ingress.yaml
+++ b/addons/monitoring/traefik/grafana-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /grafana
         pathType: Prefix

--- a/addons/monitoring/traefik/prometheus-ingress.yaml
+++ b/addons/monitoring/traefik/prometheus-ingress.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
       - path: /prometheus
         pathType: Prefix

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -7,7 +7,7 @@ categories:
   - apps/dev-and-admin-tools
 
 homepage: https://github.com/jelastic-jps/kubernetes
-baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
 logo: /images/k8s-logo.png
 
 description:

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -7,7 +7,7 @@ categories:
   - apps/dev-and-admin-tools
 
 homepage: https://github.com/jelastic-jps/kubernetes
-baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
 logo: /images/k8s-logo.png
 
 description:

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -1,13 +1,13 @@
 version: 1.5
 type: update
-id: kubernetes-upgrade-to-1.29.9
-name: Kubernetes Upgrade to 1.29.9
+id: kubernetes-upgrade-to-1.29.14
+name: Kubernetes Upgrade to 1.29.14
 
 categories:
   - apps/dev-and-admin-tools
 
 homepage: https://github.com/jelastic-jps/kubernetes
-baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
 logo: /images/k8s-logo.png
 
 description:

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -300,8 +300,8 @@ actions:
         while true; do echo "$(kubectl get nodes --no-headers 2>/dev/null)" | grep -qv '\sReady\s' || break; sleep 3; done
         /usr/local/sbin/k8sm-config -f
         kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el7.x86_64
-        yum update -y "https://repository.jelastic.com/pub/k8s/${kubeadm_package}.rpm"
-        rpm -qi "${kubeadm_package}" || exit 1
+        yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
+        rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 1
     - if (${this.main}):
         - cmd[${this.id}]: |-
@@ -371,8 +371,8 @@ actions:
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 3
     - cmd[${this.id}]: |-
         kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el7.x86_64
-        yum update -y "https://repository.jelastic.com/pub/k8s/${kubeadm_package}.rpm"
-        rpm -qi "${kubeadm_package}" || exit 1
+        yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
+        rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubeadm upgrade node || exit 4
         rm -f /etc/kubernetes/custom-kubeadm.yaml
         wget -nv ${baseUrl}/configs/redeploy.conf -O /tmp/redeploy.conf.stock

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -299,14 +299,14 @@ actions:
     - cmd[${this.id}]: |-
         while true; do echo "$(kubectl get nodes --no-headers 2>/dev/null)" | grep -qv '\sReady\s' || break; sleep 3; done
         /usr/local/sbin/k8sm-config -f
-        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el7.x86_64
+        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el9.x86_64
         yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
         rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 1
     - if (${this.main}):
         - cmd[${this.id}]: |-
             /usr/bin/kubeadm upgrade plan --ignore-preflight-errors=all || exit 2
-            /usr/bin/kubeadm upgrade apply ${this.version} || exit 2
+            /usr/bin/kubeadm upgrade apply ${this.version} --ignore-preflight-errors=CreateJob || exit 2
     - if (!${this.main}):
         - cmd[${this.id}]: |-
             /usr/bin/kubeadm upgrade node || exit 2
@@ -332,6 +332,7 @@ actions:
         while true; do [ -f "/tmp/jelastic-conf-mark" ] && break; echo "Waiting for cluster bootstrap configuration"; sleep 3; done
     - cmd[${this.id}]: |-
         systemctl restart systemd-journald.service
+        systemctl restart rsyslog.service
         systemctl restart kubelet.service
         systemctl enable kubelet.service
 
@@ -370,7 +371,7 @@ actions:
         sleep 10
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 3
     - cmd[${this.id}]: |-
-        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el7.x86_64
+        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el9.x86_64
         yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
         rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubeadm upgrade node || exit 4
@@ -389,6 +390,7 @@ actions:
         echo '${globals.worker_integration}' | base64 -d | tar zxv --strip-components=4 -C /var/lib/worker
         /usr/local/sbin/worker-integration.sh | tee -a /var/log/kubernetes/k8s-worker-integration.log
         systemctl restart systemd-journald.service
+        systemctl restart rsyslog.service
         systemctl restart kubelet.service
         systemctl enable kubelet.service
     - cmd[${nodes.k8sm.master.id}]: |-
@@ -399,7 +401,7 @@ actions:
            FAILED_PODS=$(kubectl -n kube-system get pods -l name=weave-net --no-headers | grep Error|awk '{print $1}');
            if [[ -n "$FAILED_PODS" ]] ; then
              kubectl -n kube-system delete pods $FAILED_PODS;
-           fi 
+           fi
         fi
 
 success:

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -7,7 +7,7 @@ categories:
   - apps/dev-and-admin-tools
 
 homepage: https://github.com/jelastic-jps/kubernetes
-baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
 logo: /images/k8s-logo.png
 
 description:

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -163,20 +163,32 @@ actions:
         kubectl get deployment kubernetes-dashboard -n kubernetes-dashboard && {
          kubectl delete ns kubernetes-dashboard;
          for i in {1..5}; do sleep 5; echo "Attempt ${i}/5: "; kubectl apply -f ${baseUrl}/addons/kubernetes-dashboard.yaml && break; done;
-         [ -n "${this.ingress-dir}" ] && kubectl apply -f ${baseUrl}/addons/ingress/${this.ingress-dir}/dashboard-ingress.yaml; } ||:
+         if [ -n "${this.ingress-dir}" ]; then
+          wget "${baseUrl}/addons/ingress/${this.ingress-dir}/dashboard-ingress.yaml" -O /tmp/dashboard-ingress.yaml;
+          sed -i 's/example\.com/${env.domain}/g' /tmp/dashboard-ingress.yaml;
+          kubectl apply -f /tmp/dashboard-ingress.yaml; fi; } ||:
     - cmd[${nodes.k8sm.master.id}]: |-
         kubectl get deployment kubernetes-skooner -n kubernetes-skooner && {
          kubectl delete ns kubernetes-skooner;
          for i in {1..5}; do sleep 5; echo "Attempt ${i}/5: "; kubectl apply -f ${baseUrl}/addons/kubernetes-skooner.yaml && break; done;
-         [ -n "${this.ingress-dir}" ] && kubectl apply -f ${baseUrl}/addons/ingress/${this.ingress-dir}/skooner-ingress.yaml; } ||:
+         if [ -n "${this.ingress-dir}" ]; then
+          wget "${baseUrl}/addons/ingress/${this.ingress-dir}/skooner-ingress.yaml" -O /tmp/skooner-ingress.yaml;
+          sed -i 's/example\.com/${env.domain}/g' /tmp/skooner-ingress.yaml;
+          kubectl apply -f /tmp/skooner-ingress.yaml; fi; } ||:
     - cmd[${nodes.k8sm.master.id}]: |-
         kubectl get ingress kubernetes-api -n default && {
-         [ -n "${this.ingress-dir}" ] && kubectl apply -f ${baseUrl}/addons/ingress/${this.ingress-dir}/api-ingress.yaml; } ||:
+         if [ -n "${this.ingress-dir}" ]; then
+          wget "${baseUrl}/addons/ingress/${this.ingress-dir}/api-ingress.yaml" -O /tmp/api-ingress.yaml;
+          sed -i 's/example\.com/${env.domain}/g' /tmp/api-ingress.yaml;
+          kubectl apply -f /tmp/api-ingress.yaml; fi; } ||:
     - cmd[${nodes.k8sm.master.id}]: |-
         kubectl get deployment hello-kubernetes && {
          kubectl delete -f ${baseUrl}/addons/helloworld.yaml;
          kubectl apply -f ${baseUrl}/addons/helloworld.yaml;
-         [ -n "${this.ingress-dir}" ] && kubectl apply -f ${baseUrl}/addons/ingress/${this.ingress-dir}/helloworld-ingress.yaml; } ||:
+         if [ -n "${this.ingress-dir}" ]; then
+          wget "${baseUrl}/addons/ingress/${this.ingress-dir}/helloworld-ingress.yaml" -O /tmp/helloworld-ingress.yaml;
+          sed -i 's/example\.com/${env.domain}/g' /tmp/helloworld-ingress.yaml;
+          kubectl apply -f /tmp/helloworld-ingress.yaml; fi; } ||:
     - cmd[${nodes.k8sm.master.id}]: |-
         helm list | grep -q "nfs-client-provisioner" && {
          helm get values nfs-client-provisioner -o yaml > /tmp/nfs-provisioner-options.yaml;
@@ -206,12 +218,17 @@ actions:
          wait-deployment.sh monitoring-grafana kubernetes-monitoring 1 720;
          kubectl patch secret --namespace kubernetes-monitoring monitoring-grafana -p="{\"data\":{\"admin-password\":\"${grafana_base64}\"}}";
          if [ -n "${this.ingress-dir}" ]; then
-          kubectl apply -f ${baseUrl}/addons/monitoring/${this.ingress-dir}/prometheus-ingress.yaml;
-          kubectl apply -f ${baseUrl}/addons/monitoring/${this.ingress-dir}/alert-ingress.yaml;
-          kubectl apply -f ${baseUrl}/addons/monitoring/${this.ingress-dir}/grafana-ingress.yaml; fi; } ||:
+          for ingress_name in prometheus alert grafana; do
+           wget "${baseUrl}/addons/monitoring/${this.ingress-dir}/${ingress_name}-ingress.yaml" -O "/tmp/${ingress_name}-ingress.yaml";
+           sed -i 's/example\.com/${env.domain}/g' "/tmp/${ingress_name}-ingress.yaml";
+           kubectl apply -f "/tmp/${ingress_name}-ingress.yaml";
+          done; fi; } ||:
     - cmd[${nodes.k8sm.master.id}]: |-
         kubectl get secret --namespace observability observability-jaeger-plain && {
-         [ -n "${this.ingress-dir}" ] && kubectl apply -f ${baseUrl}/addons/ingress/${this.ingress-dir}/jaeger-ingress.yaml; } ||:
+         if [ -n "${this.ingress-dir}" ]; then
+          wget "${baseUrl}/addons/ingress/${this.ingress-dir}/jaeger-ingress.yaml" -O /tmp/jaeger-ingress.yaml;
+          sed -i 's/example\.com/${env.domain}/g' /tmp/jaeger-ingress.yaml;
+          kubectl apply -f /tmp/jaeger-ingress.yaml; fi; } ||:
 
   upgrade-jps-manifests:
     - version: ${this}

--- a/addons/upgrade.jps
+++ b/addons/upgrade.jps
@@ -22,28 +22,28 @@ onInstall:
       id: ${nodes.k8sm.master.id}
       main: true
       hostname: node${nodes.k8sm.master.id}-${env.domain}
-      version: ${settings.version}
+      version: v1.29.14
   - forEach(nodes.k8sm):
       if (!${@i.ismaster}):
         upgrade-cplanes-cluster:
           id: ${@i.id}
           main: false
           hostname: node${@i.id}-${env.domain}
-          version: ${settings.version}
-  - upgrade-jps-manifests: ${settings.version}
+          version: v1.29.14
+  - upgrade-jps-manifests: v1.29.14
   - env.control.ApplyNodeGroupData [k8sm]:
       data:
         isRedeploySupport: true
   - upgrade-cplanes-redeploy:
       id: ${nodes.k8sm.master.id}
       main: true
-      version: ${settings.version}
+      version: v1.29.14
   - forEach(nodes.k8sm):
       if (!${@i.ismaster}):
         upgrade-cplanes-redeploy:
           id: ${@i.id}
           main: false
-          version: ${settings.version}
+          version: v1.29.14
   - upgrade-cplanes-post:
       id: ${nodes.k8sm.master.id}
       main: true
@@ -64,7 +64,7 @@ onInstall:
             id: ${@node.id}
             group: ${@group}
             hostname: node${@node.id}-${env.domain}
-            version: ${settings.version}
+            version: v1.29.14
   - env.control.ApplyNodeGroupData [${globals.workers}]:
       data:
         validation:
@@ -74,7 +74,7 @@ onInstall:
         path: /etc/jelastic/redeploy.conf
         isDir: false
   - script: |
-      var message = "Kubernetes Cluster has been successfuly upgraded! **Current version:** ${settings.version}.";
+      var message = "Kubernetes Cluster has been successfuly upgraded! **Current version:** v1.29.14.";
       if ("${settings.avail}") { message += "\n\n**Next version:** ${settings.avail}.  \nPress \"Upgrade\" button to start the upgrade process."; }
       else { message += "\n\nNo other upgrades are available."; }
       return {result:"info", message:message};
@@ -299,7 +299,8 @@ actions:
     - cmd[${this.id}]: |-
         while true; do echo "$(kubectl get nodes --no-headers 2>/dev/null)" | grep -qv '\sReady\s' || break; sleep 3; done
         /usr/local/sbin/k8sm-config -f
-        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el9.x86_64
+        upgrade_version="1.29.14"
+        kubeadm_package="kubeadm-$upgrade_version-1.el9.x86_64"
         yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
         rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 1
@@ -371,7 +372,8 @@ actions:
         sleep 10
         /usr/bin/kubectl drain ${this.hostname} --ignore-daemonsets --delete-emptydir-data || exit 3
     - cmd[${this.id}]: |-
-        kubeadm_package=kubeadm-$(echo '${this.version}' | cut -d 'v' -f2)-1.el9.x86_64
+        upgrade_version="1.29.14"
+        kubeadm_package="kubeadm-$upgrade_version-1.el9.x86_64"
         yum update -y "https://repository.jelastic.com/pub/k8s/$kubeadm_package.rpm"
         rpm -qi "$kubeadm_package" || exit 1
         /usr/bin/kubeadm upgrade node || exit 4

--- a/configs/autotest.yaml
+++ b/configs/autotest.yaml
@@ -4,11 +4,11 @@ id: kubernetes
 jaegerAction: addon-jaeger
 monitoringAction: addon-monitoring
 helm.version: v3.15.4
-cni.plugins.version: 1.3.0
+cni.plugins.version: 1.9.0
 k9s.version: 0.32.5
 crictl.version: v1.29.0
-stern.version: 1.30.0
-containerd.version: 1.7.21
+stern.version: 1.29.0
+containerd.version: 1.7.29
 ingress.nginx.version: 1.11.2
 kubernetes.dashboard.version: 2.7.0
 metallb.version: 0.14.8

--- a/configs/autotest.yaml
+++ b/configs/autotest.yaml
@@ -7,7 +7,7 @@ helm.version: v3.15.4
 cni.plugins.version: 1.9.0
 k9s.version: 0.32.5
 crictl.version: v1.29.0
-stern.version: 1.29.0
+stern.version: 1.30.0
 containerd.version: 1.7.29
 ingress.nginx.version: 1.11.2
 kubernetes.dashboard.version: 2.7.0

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -20,7 +20,7 @@ fields:
           kubectl apply -f https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-crd.yaml
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14/addons/open-liberty.yaml
+          kubectl apply -f https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14/addons/open-liberty.yaml
 
   - name: label
     caption: Topology

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -20,7 +20,7 @@ fields:
           kubectl apply -f https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-crd.yaml
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9/addons/open-liberty.yaml
+          kubectl apply -f https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/addons/open-liberty.yaml
 
   - name: label
     caption: Topology
@@ -101,4 +101,4 @@ fields:
     name: version
     inputType: hidden
     caption: Kubernetes Version
-    default: v1.29.9
+    default: v1.29.14

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -20,7 +20,7 @@ fields:
           kubectl apply -f https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-crd.yaml
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/addons/open-liberty.yaml
+          kubectl apply -f https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14/addons/open-liberty.yaml
 
   - name: label
     caption: Topology

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -20,7 +20,7 @@ fields:
           kubectl apply -f https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-crd.yaml
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://cdn.jsdelivr.net/gh/OpenLiberty/open-liberty-operator@main/deploy/releases/1.3.3/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14/addons/open-liberty.yaml
+          kubectl apply -f https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/addons/open-liberty.yaml
 
   - name: label
     caption: Topology

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes-release
-baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.
@@ -564,7 +564,7 @@ addons:
   - id: conf-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: Cluster Configuration
     description: Configure remote API access and install complementary tools
     logo: /images/k8s-config.png
@@ -725,7 +725,7 @@ addons:
   - id: monitor-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: Cluster Monitoring
     description: Install cluster monitoring components (Prometheus and Grafana)
     logo: /images/k8s-monitor.png
@@ -750,7 +750,7 @@ addons:
   - id: upgrade-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: Cluster Upgrade
     description: Upgrade Kubernetes cluster to a newer version
     logo: /images/k8s-upgrade.png
@@ -959,7 +959,7 @@ addons:
   - id: certman-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: Certificate Manager
     description: |
       Kubernetes SSL Certificate Manager allows to bind custom domain names
@@ -1003,7 +1003,7 @@ addons:
   - id: rancher-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: Rancher Installer
     description: Rancher Management Platform
     logo: /images/k8s-rancher.png
@@ -1070,7 +1070,7 @@ addons:
   - id: regcreds-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
     name: DockerHub Registry Credentials
     description: |
       Leverage DockerHub images pull rate limits: assign DockerHub user credentials to Kubernetes deployments cluster-wide

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes-release
-baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.
@@ -564,7 +564,7 @@ addons:
   - id: conf-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: Cluster Configuration
     description: Configure remote API access and install complementary tools
     logo: /images/k8s-config.png
@@ -725,7 +725,7 @@ addons:
   - id: monitor-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: Cluster Monitoring
     description: Install cluster monitoring components (Prometheus and Grafana)
     logo: /images/k8s-monitor.png
@@ -750,7 +750,7 @@ addons:
   - id: upgrade-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: Cluster Upgrade
     description: Upgrade Kubernetes cluster to a newer version
     logo: /images/k8s-upgrade.png
@@ -867,7 +867,13 @@ addons:
           }
 
           function startUpgrade(version, next, upgrades) {
-            var baseUrl = "${baseUrl}".replace(/@[^\/]+/, "@" + next);
+            var baseUrl = "${baseUrl}";
+            var versionSeparator = baseUrl.lastIndexOf("@");
+            if (versionSeparator >= 0) {
+              baseUrl = baseUrl.substring(0, versionSeparator + 1) + next;
+            } else {
+              baseUrl = baseUrl.substring(0, baseUrl.lastIndexOf("/") + 1) + next;
+            }
             var url = baseUrl + "/addons/upgrade.jps";
             var huc = new java.net.URL(url).openConnection();
             huc.setRequestMethod("HEAD");
@@ -959,7 +965,7 @@ addons:
   - id: certman-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: Certificate Manager
     description: |
       Kubernetes SSL Certificate Manager allows to bind custom domain names
@@ -1003,7 +1009,7 @@ addons:
   - id: rancher-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: Rancher Installer
     description: Rancher Management Platform
     logo: /images/k8s-rancher.png
@@ -1070,7 +1076,7 @@ addons:
   - id: regcreds-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14
+    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
     name: DockerHub Registry Credentials
     description: |
       Leverage DockerHub images pull rate limits: assign DockerHub user credentials to Kubernetes deployments cluster-wide

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes-release
-baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.
@@ -10,7 +10,7 @@ categories:
   - apps/dev-and-admin-tools
 
 logo: /images/k8s-logo.png
-name: Kubernetes Cluster v1.29.9
+name: Kubernetes Cluster v1.29.14
 targetRegions:
   type: vz7
 
@@ -564,7 +564,7 @@ addons:
   - id: conf-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Configuration
     description: Configure remote API access and install complementary tools
     logo: /images/k8s-config.png
@@ -725,7 +725,7 @@ addons:
   - id: monitor-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Monitoring
     description: Install cluster monitoring components (Prometheus and Grafana)
     logo: /images/k8s-monitor.png
@@ -750,7 +750,7 @@ addons:
   - id: upgrade-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Upgrade
     description: Upgrade Kubernetes cluster to a newer version
     logo: /images/k8s-upgrade.png
@@ -959,7 +959,7 @@ addons:
   - id: certman-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Certificate Manager
     description: |
       Kubernetes SSL Certificate Manager allows to bind custom domain names
@@ -1003,7 +1003,7 @@ addons:
   - id: rancher-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Rancher Installer
     description: Rancher Management Platform
     logo: /images/k8s-rancher.png
@@ -1070,7 +1070,7 @@ addons:
   - id: regcreds-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: DockerHub Registry Credentials
     description: |
       Leverage DockerHub images pull rate limits: assign DockerHub user credentials to Kubernetes deployments cluster-wide

--- a/manifest.jps
+++ b/manifest.jps
@@ -1022,11 +1022,6 @@ addons:
 
     actions:
       addon-rancher:
-      - cmd[${nodes.k8sm.master.id}]: kubectl -n cattle-system get deployment rancher &>/dev/null && echo "true" || echo "false"
-      - if ('${response.out}' == 'true'):
-          return:
-            type: info
-            message: Rancher Management Platform is already installed!
       - init-globals-ingress
       - if ('${globals.ingress-dir}' != 'nginx'):
           return:
@@ -1036,425 +1031,59 @@ addons:
           kubectl delete -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/helloworld-ingress.yaml ||:
           kubectl delete -f ${baseUrl}/addons/helloworld.yaml ||:
       - cmd[${nodes.k8sm.master.id}]: |-
-          http_code=$(curl -Lks -o /dev/null -w "%{http_code}" "${env.url}")
-          ret_code=$?
-          if [ ${ret_code} -ne 0 ]; then
-            echo "An error occurred while accessing the [endpoint](${env.url})"
-          elif [ ${http_code} -eq 200 ]; then
-            echo "The [endpoint](${env.url}) is already taken"
-          elif [ ${http_code} -ne 404 ]; then
-            echo "The [endpoint](${env.url}) is present and answered with HTTP code ${http_code}"
-          fi
+          kubectl get ingress -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{range .spec.rules[*]}{.host}{" "}{range .http.paths[*]}{.path}{"\n"}{end}{end}{end}' |
+            awk '$3 == "${env.domain}" && ($4 == "/" || $4 == "") && !($1 == "cattle-system" && $2 == "rancher") { print $1 "/" $2 }'
       - if ('${response.out}'):
           return:
             type: warning
-            message: Cannot deploy Rancher UI! ${response.out}.
-      - cmd[${nodes.k8sm.master.id}]: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+            message: Cannot deploy Rancher UI. Root ingress for ${env.domain} is already used by ${response.out}.
+      - cmd[${nodes.k8sm.master.id}]: kubectl -n cattle-system get deployment rancher &>/dev/null && echo "true" || echo "false"
       - set:
-          rancher_secret: ${response.out}
+          rancher_existing: ${response.out}
+      - if ('${this.rancher_existing}' != 'true'):
+          - cmd[${nodes.k8sm.master.id}]: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+          - set:
+              rancher_secret: ${response.out}
+      - else:
+          - set:
+              rancher_secret: ""
       - cmd[${nodes.k8sm.master.id}]: |-
-          set -Eeuo pipefail
-
-          # Rancher addon constants. Change these values to select another supported version.
-          rancher_version="2.10.3"
-          cert_manager_version="v1.16.2"
-          rancher_chart_repo_name="rancher-latest"
-          rancher_chart_repo_url="https://releases.rancher.com/server-charts/latest"
-          rancher_namespace="cattle-system"
-          cert_manager_namespace="cert-manager"
-          ingress_class_name="nginx"
-          ca_bundle_source="/etc/pki/tls/certs/ca-bundle.crt"
-          wait_timeout="30m"
-          rancher_stable_seconds="180"
-          rancher_prepull="true"
-
-          rancher_image_tag="v$(printf '%s' "$rancher_version" | sed 's/^v//')"
-          rancher_hostname="${env.domain}"
-          bootstrap_password="${this.rancher_secret}"
-          tmp_files=""
-
-          cleanup_rancher_install() {
-            for item in $tmp_files; do
-              rm -f "$item" 2>/dev/null || true
-            done
-            if [ "$rancher_prepull" = "true" ]; then
-              kubectl -n "$rancher_namespace" delete daemonset rancher-image-prepull --ignore-not-found --wait=false >/dev/null 2>&1 || true
-            fi
-          }
-          trap cleanup_rancher_install EXIT
-
-          require_cmd() {
-            command -v "$1" >/dev/null 2>&1 || {
-              echo "ERROR: required command not found: $1" >&2
+          rancher_installer="/tmp/install-rancher-workarounds.sh"
+          rancher_installer_url="${baseUrl}/scripts/install-rancher-workarounds.sh"
+          if ! curl -fsSL "$rancher_installer_url" -o "$rancher_installer"; then
+            if ! wget -qO "$rancher_installer" "$rancher_installer_url"; then
+              echo "ERROR: cannot download Rancher installer helper from $rancher_installer_url" >&2
               exit 2
-            }
-          }
-
-          log_step() {
-            printf '\n== %s ==\n' "$*"
-          }
-
-          yaml_quote() {
-            printf "'"
-            printf "%s" "$1" | sed "s/'/''/g"
-            printf "'"
-          }
-
-          write_rancher_values_file() {
-            values_file="$(mktemp)"
-            tmp_files="$tmp_files $values_file"
-
-            cat >"$values_file" <<EOF
-          hostname: $(yaml_quote "$rancher_hostname")
-          bootstrapPassword: $(yaml_quote "$bootstrap_password")
-          replicas: 1
-          ingress:
-            ingressClassName: $(yaml_quote "$ingress_class_name")
-            tls:
-              source: rancher
-          tls: ingress
-          additionalTrustedCAs: true
-          useBundledSystemChart: true
-          startupProbe:
-            failureThreshold: 180
-            periodSeconds: 10
-            timeoutSeconds: 5
-          livenessProbe:
-            failureThreshold: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          readinessProbe:
-            failureThreshold: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
-          extraEnv:
-          - name: CURL_CA_BUNDLE
-            value: /etc/rancher/ssl/ca-additional.pem
-          - name: SSL_CERT_FILE
-            value: /etc/rancher/ssl/ca-additional.pem
-          EOF
-          }
-
-          write_rancher_post_renderer() {
-            post_renderer="$(mktemp)"
-            tmp_files="$tmp_files $post_renderer"
-
-            cat >"$post_renderer" <<'POST_RENDERER'
-          #!/usr/bin/env bash
-          set -Eeuo pipefail
-
-          workdir="$(mktemp -d)"
-          trap 'rm -rf "$workdir"' EXIT
-
-          cat >"$workdir/all.yaml"
-          cat >"$workdir/kustomization.yaml" <<'KUSTOMIZE'
-          resources:
-          - all.yaml
-          patchesStrategicMerge:
-          - rancher-workarounds.yaml
-          KUSTOMIZE
-
-          cat >"$workdir/rancher-workarounds.yaml" <<'PATCH'
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: rancher
-          spec:
-            progressDeadlineSeconds: 3600
-            template:
-              spec:
-                initContainers:
-                - name: rancher-jailer-patch
-                  image: rancher/rancher:__RANCHER_IMAGE_TAG__
-                  imagePullPolicy: IfNotPresent
-                  command:
-                  - /bin/sh
-                  - -ec
-                  args:
-                  - |
-                    sed -e 's/cp -r -l /cp -r /g' -e 's/cp -l /cp /g' /usr/bin/jailer.sh > /patched/jailer.sh
-                    chmod 0755 /patched/jailer.sh
-                    echo "patched /usr/bin/jailer.sh created"
-                    grep -nE 'cp[[:space:]]+(-r[[:space:]]+)?-?l|cp[[:space:]]+-r|cp[[:space:]]+' /patched/jailer.sh | head -40 || true
-                  volumeMounts:
-                  - name: rancher-jailer-script
-                    mountPath: /patched
-                containers:
-                - name: rancher
-                  env:
-                  - name: CATTLE_SYSTEM_CATALOG
-                    value: bundled
-                  - name: CURL_CA_BUNDLE
-                    value: /etc/rancher/ssl/ca-additional.pem
-                  - name: SSL_CERT_FILE
-                    value: /etc/rancher/ssl/ca-additional.pem
-                  volumeMounts:
-                  - name: rancher-jailer-script
-                    mountPath: /usr/bin/jailer.sh
-                    subPath: jailer.sh
-                    readOnly: true
-                  - name: rancher-jail
-                    mountPath: /opt/jail
-                  - name: tls-ca-additional-volume
-                    mountPath: /etc/rancher/ssl/ca-additional.pem
-                    subPath: ca-additional.pem
-                    readOnly: true
-                  - name: tls-ca-additional-volume
-                    mountPath: /etc/pki/trust/anchors/ca-additional.pem
-                    subPath: ca-additional.pem
-                    readOnly: true
-                volumes:
-                - name: rancher-jailer-script
-                  emptyDir: {}
-                - name: rancher-jail
-                  emptyDir:
-                    medium: Memory
-                    sizeLimit: 1Gi
-                - name: tls-ca-additional-volume
-                  secret:
-                    secretName: tls-ca-additional
-                    optional: false
-          PATCH
-
-          sed -i "s/__RANCHER_IMAGE_TAG__/$RANCHER_IMAGE_TAG/g" "$workdir/rancher-workarounds.yaml"
-          kubectl kustomize "$workdir"
-          POST_RENDERER
-
-            chmod 0700 "$post_renderer"
-          }
-
-          start_rancher_image_prepull() {
-            if [ "$rancher_prepull" != "true" ]; then
-              return 0
             fi
-
-            log_step "Pre-pull Rancher image on schedulable nodes"
-            kubectl -n "$rancher_namespace" apply -f - <<EOF
-          apiVersion: apps/v1
-          kind: DaemonSet
-          metadata:
-            name: rancher-image-prepull
-            labels:
-              app: rancher-image-prepull
-          spec:
-            selector:
-              matchLabels:
-                app: rancher-image-prepull
-            template:
-              metadata:
-                labels:
-                  app: rancher-image-prepull
-              spec:
-                terminationGracePeriodSeconds: 1
-                containers:
-                - name: prepull
-                  image: rancher/rancher:$rancher_image_tag
-                  imagePullPolicy: IfNotPresent
-                  command:
-                  - /bin/sh
-                  - -ec
-                  - sleep 1800
-          EOF
-          }
-
-          refresh_tls_ca_secret() {
-            get_error="$(mktemp)"
-            patch_file="$(mktemp)"
-            tmp_files="$tmp_files $get_error $patch_file"
-
-            if kubectl -n "$rancher_namespace" get secret tls-ca-additional >/dev/null 2>"$get_error"; then
-              ca_data="$(base64 "$ca_bundle_source" | tr -d '\n')"
-              cat >"$patch_file" <<EOF
-          {"data":{"ca-additional.pem":"$ca_data"}}
-          EOF
-              if kubectl patch --help 2>/dev/null | grep -q -- '--patch-file'; then
-                kubectl -n "$rancher_namespace" patch secret tls-ca-additional \
-                  --type=merge \
-                  --patch-file "$patch_file"
-              else
-                kubectl -n "$rancher_namespace" patch secret tls-ca-additional \
-                  --type=merge \
-                  -p "$(cat "$patch_file")"
-              fi
-            else
-              get_rc=$?
-              if grep -Eqi 'notfound|not found' "$get_error"; then
-                kubectl -n "$rancher_namespace" create secret generic tls-ca-additional \
-                  --from-file=ca-additional.pem="$ca_bundle_source"
-              else
-                cat "$get_error" >&2
-                return "$get_rc"
-              fi
-            fi
-          }
-
-          wait_rancher_stable() {
-            stable=0
-            last_restarts=""
-            interval=15
-
-            log_step "Wait for Rancher to remain Ready for $rancher_stable_seconds seconds"
-            while [ "$stable" -lt "$rancher_stable_seconds" ]; do
-              pod_line="$(
-                kubectl -n "$rancher_namespace" get pods -l app=rancher \
-                  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.status.containerStatuses[?(@.name=="rancher")].ready}{" "}{.status.containerStatuses[?(@.name=="rancher")].restartCount}{"\n"}{end}' \
-                  | head -1
-              )"
-              set -- $pod_line none none none none
-              pod_name="$1"
-              pod_phase="$2"
-              pod_ready="$3"
-              pod_restarts="$4"
-
-              if [ "$pod_phase" = "Running" ] && [ "$pod_ready" = "true" ]; then
-                if [ "$pod_restarts" = "$last_restarts" ]; then
-                  stable=$((stable + interval))
-                else
-                  stable=0
-                  last_restarts="$pod_restarts"
-                fi
-                printf 'Rancher ready: pod=%s restarts=%s stable=%ss/%ss\n' \
-                  "$pod_name" "$pod_restarts" "$stable" "$rancher_stable_seconds"
-              else
-                stable=0
-                last_restarts="$pod_restarts"
-                [ -n "$pod_name" ] || pod_name="none"
-                [ -n "$pod_phase" ] || pod_phase="none"
-                [ -n "$pod_ready" ] || pod_ready="none"
-                [ -n "$pod_restarts" ] || pod_restarts="none"
-                printf 'Rancher not stable yet: pod=%s phase=%s ready=%s restarts=%s\n' \
-                  "$pod_name" "$pod_phase" "$pod_ready" "$pod_restarts"
-              fi
-
-              sleep "$interval"
-            done
-          }
-
-          wait_https_ok() {
-            log_step "Wait for Rancher HTTPS endpoint"
-            for attempt in $(seq 1 80); do
-              http_code="$(curl -kIs -o /dev/null -w '%{http_code}' --max-time 15 "https://$rancher_hostname" 2>/dev/null || true)"
-              if [ "$http_code" = "200" ]; then
-                curl -kIs --max-time 15 "https://$rancher_hostname" | sed -n '1,12p'
-                return 0
-              fi
-              [ -n "$http_code" ] || http_code="curl_failed"
-              echo "HTTPS not ready yet: HTTP $http_code"
-              sleep 15
-            done
-
-            echo "ERROR: Rancher HTTPS endpoint did not return HTTP 200" >&2
-            return 1
-          }
-
-          require_cmd kubectl
-          require_cmd helm
-          require_cmd openssl
-          require_cmd curl
-          kubectl kustomize --help >/dev/null 2>&1 || {
-            echo "ERROR: kubectl kustomize is required for Helm post-rendering" >&2
-            exit 2
-          }
-          if [ ! -r "$ca_bundle_source" ]; then
-            echo "ERROR: CA bundle is not readable: $ca_bundle_source" >&2
-            exit 2
           fi
-
-          log_step "Helm repositories"
-          helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
-          helm repo add "$rancher_chart_repo_name" "$rancher_chart_repo_url" --force-update >/dev/null
-          helm repo update >/dev/null
-
-          log_step "Namespaces"
-          kubectl create namespace "$cert_manager_namespace" --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create namespace "$rancher_namespace" --dry-run=client -o yaml | kubectl apply -f -
-
-          log_step "Install or update cert-manager"
-          helm upgrade --install cert-manager jetstack/cert-manager \
-            --namespace "$cert_manager_namespace" \
-            --version "$cert_manager_version" \
-            --set crds.enabled=true \
-            --wait \
-            --timeout "$wait_timeout"
-
-          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager --timeout="$wait_timeout"
-          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager-webhook --timeout="$wait_timeout"
-          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager-cainjector --timeout="$wait_timeout"
-
-          start_rancher_image_prepull
-
-          log_step "Additional CA secret for Rancher"
-          refresh_tls_ca_secret
-
-          log_step "Install Rancher Helm release"
-          write_rancher_values_file
-          export RANCHER_IMAGE_TAG="$rancher_image_tag"
-          write_rancher_post_renderer
-
-          if [ "$rancher_prepull" = "true" ]; then
-            kubectl -n "$rancher_namespace" rollout status daemonset/rancher-image-prepull --timeout="$wait_timeout" || true
+          chmod 0700 "$rancher_installer"
+          if [ -n "${this.rancher_secret}" ]; then
+            RANCHER_HOSTNAME="${env.domain}" BOOTSTRAP_PASSWORD="${this.rancher_secret}" bash "$rancher_installer"
+          else
+            RANCHER_HOSTNAME="${env.domain}" bash "$rancher_installer"
           fi
+      - if ('${this.rancher_existing}' != 'true'):
+          - message.email.send:
+              to: "${user.email}"
+              subject: Rancher Platform Successfully Installed in ${env.name}
+              body: |-
+                Rancher Management Platform installed in <b>${env.name}</b> Kubernetes Cluster: <br>
+                Rancher Dashboard - ${env.url}<br>
+                Your login password: ${this.rancher_secret}
+          - return:
+              type: success
+              message: |
+                Rancher Platform has been successfully installed!
 
-          helm upgrade --install rancher "$rancher_chart_repo_name/rancher" \
-            --namespace "$rancher_namespace" \
-            --version "$rancher_version" \
-            -f "$values_file" \
-            --post-renderer "$post_renderer" \
-            --wait=false \
-            --timeout "$wait_timeout"
+                Enter [Rancher dashboard](${env.url}), using password:
 
-          log_step "Stop stale Rancher ReplicaSets without the jailer patch"
-          while read -r rs; do
-            [ -n "$rs" ] || continue
-            init_names="$(kubectl -n "$rancher_namespace" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[*].name}' 2>/dev/null || true)"
-            init_image="$(kubectl -n "$rancher_namespace" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[?(@.name=="rancher-jailer-patch")].image}' 2>/dev/null || true)"
-            case "$init_names" in
-              *rancher-jailer-patch*) has_jailer_patch="true" ;;
-              *) has_jailer_patch="false" ;;
-            esac
-            if [ "$has_jailer_patch" != "true" ] || [ "$init_image" != "rancher/rancher:$rancher_image_tag" ]; then
-              echo "Scaling stale or incorrectly patched $rs to 0"
-              kubectl -n "$rancher_namespace" scale "$rs" --replicas=0
-            else
-              echo "Keeping patched $rs"
-            fi
-          done <<EOF
-          $(kubectl -n "$rancher_namespace" get rs -l app=rancher -o name)
-          EOF
-
-          log_step "Wait for Rancher"
-          kubectl -n "$rancher_namespace" rollout status deployment/rancher --timeout="$wait_timeout" || {
-            echo "Rancher did not become Ready. Recent status and logs follow." >&2
-            kubectl -n "$rancher_namespace" get deploy,rs,pods,svc,ingress -l app=rancher -o wide >&2 || true
-            kubectl -n "$rancher_namespace" logs -l app=rancher --all-containers --tail=250 --prefix >&2 || true
-            exit 1
-          }
-
-          kubectl -n "$rancher_namespace" get deploy,rs,pods,svc,ingress -l app=rancher -o wide
-          kubectl -n "$rancher_namespace" get issuer,certificate,certificaterequest 2>/dev/null || true
-
-          wait_rancher_stable
-
-          log_step "Wait for Rancher ingress certificate"
-          kubectl -n "$rancher_namespace" wait --for=condition=Ready issuer/rancher --timeout="$wait_timeout"
-          kubectl -n "$rancher_namespace" wait --for=condition=Ready certificate/tls-rancher-ingress --timeout="$wait_timeout"
-
-          wait_https_ok
-      - message.email.send:
-          to: "${user.email}"
-          subject: Rancher Platform Successfully Installed in ${env.name}
-          body: |-
-            Rancher Management Platform installed in <b>${env.name}</b> Kubernetes Cluster: <br>
-            Rancher Dashboard - ${env.url}<br>
-            Your login password: ${this.rancher_secret}
+                ```${this.rancher_secret}```
       - return:
           type: success
           message: |
-            Rancher Platform has been successfully installed!
+            Rancher Platform has been successfully repaired or updated.
 
-            Enter [Rancher dashboard](${env.url}), using password:
-
-            ```${this.rancher_secret}```
+            Existing Rancher credentials were not changed.
 
   - id: regcreds-k8s-addon
     type: update

--- a/manifest.jps
+++ b/manifest.jps
@@ -1257,6 +1257,37 @@ addons:
           EOF
           }
 
+          refresh_tls_ca_secret() {
+            get_error="$(mktemp)"
+            patch_file="$(mktemp)"
+            tmp_files="$tmp_files $get_error $patch_file"
+
+            if kubectl -n "$rancher_namespace" get secret tls-ca-additional >/dev/null 2>"$get_error"; then
+              ca_data="$(base64 "$ca_bundle_source" | tr -d '\n')"
+              cat >"$patch_file" <<EOF
+          {"data":{"ca-additional.pem":"$ca_data"}}
+          EOF
+              if kubectl patch --help 2>/dev/null | grep -q -- '--patch-file'; then
+                kubectl -n "$rancher_namespace" patch secret tls-ca-additional \
+                  --type=merge \
+                  --patch-file "$patch_file"
+              else
+                kubectl -n "$rancher_namespace" patch secret tls-ca-additional \
+                  --type=merge \
+                  -p "$(cat "$patch_file")"
+              fi
+            else
+              get_rc=$?
+              if grep -Eqi 'notfound|not found' "$get_error"; then
+                kubectl -n "$rancher_namespace" create secret generic tls-ca-additional \
+                  --from-file=ca-additional.pem="$ca_bundle_source"
+              else
+                cat "$get_error" >&2
+                return "$get_rc"
+              fi
+            fi
+          }
+
           wait_rancher_stable() {
             stable=0
             last_restarts=""
@@ -1353,9 +1384,7 @@ addons:
           start_rancher_image_prepull
 
           log_step "Additional CA secret for Rancher"
-          kubectl -n "$rancher_namespace" create secret generic tls-ca-additional \
-            --from-file=ca-additional.pem="$ca_bundle_source" \
-            --dry-run=client -o yaml | kubectl apply -f -
+          refresh_tls_ca_secret
 
           log_step "Install Rancher Helm release"
           write_rancher_values_file

--- a/manifest.jps
+++ b/manifest.jps
@@ -1053,10 +1053,364 @@ addons:
       - set:
           rancher_secret: ${response.out}
       - cmd[${nodes.k8sm.master.id}]: |-
-          helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-          helm repo update
-          helm install rancher rancher-stable/rancher --create-namespace --namespace cattle-system --set tls=external --set bootstrapPassword="${this.rancher_secret}"
-          kubectl -n cattle-system rollout status deploy/rancher
+          set -Eeuo pipefail
+
+          # Rancher addon constants. Change these values to select another supported version.
+          rancher_version="2.10.3"
+          cert_manager_version="v1.16.2"
+          rancher_chart_repo_name="rancher-latest"
+          rancher_chart_repo_url="https://releases.rancher.com/server-charts/latest"
+          rancher_namespace="cattle-system"
+          cert_manager_namespace="cert-manager"
+          ingress_class_name="nginx"
+          ca_bundle_source="/etc/pki/tls/certs/ca-bundle.crt"
+          wait_timeout="30m"
+          rancher_stable_seconds="180"
+          rancher_prepull="true"
+
+          rancher_image_tag="v$(printf '%s' "$rancher_version" | sed 's/^v//')"
+          rancher_hostname="${env.domain}"
+          bootstrap_password="${this.rancher_secret}"
+          tmp_files=""
+
+          cleanup_rancher_install() {
+            for item in $tmp_files; do
+              rm -f "$item" 2>/dev/null || true
+            done
+            if [ "$rancher_prepull" = "true" ]; then
+              kubectl -n "$rancher_namespace" delete daemonset rancher-image-prepull --ignore-not-found --wait=false >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_rancher_install EXIT
+
+          require_cmd() {
+            command -v "$1" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found: $1" >&2
+              exit 2
+            }
+          }
+
+          log_step() {
+            printf '\n== %s ==\n' "$*"
+          }
+
+          yaml_quote() {
+            printf "'"
+            printf "%s" "$1" | sed "s/'/''/g"
+            printf "'"
+          }
+
+          write_rancher_values_file() {
+            values_file="$(mktemp)"
+            tmp_files="$tmp_files $values_file"
+
+            cat >"$values_file" <<EOF
+          hostname: $(yaml_quote "$rancher_hostname")
+          bootstrapPassword: $(yaml_quote "$bootstrap_password")
+          replicas: 1
+          ingress:
+            ingressClassName: $(yaml_quote "$ingress_class_name")
+            tls:
+              source: rancher
+          tls: ingress
+          additionalTrustedCAs: true
+          useBundledSystemChart: true
+          startupProbe:
+            failureThreshold: 180
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            failureThreshold: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          extraEnv:
+          - name: CURL_CA_BUNDLE
+            value: /etc/rancher/ssl/ca-additional.pem
+          - name: SSL_CERT_FILE
+            value: /etc/rancher/ssl/ca-additional.pem
+          EOF
+          }
+
+          write_rancher_post_renderer() {
+            post_renderer="$(mktemp)"
+            tmp_files="$tmp_files $post_renderer"
+
+            cat >"$post_renderer" <<'POST_RENDERER'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+
+          cat >"$workdir/all.yaml"
+          cat >"$workdir/kustomization.yaml" <<'KUSTOMIZE'
+          resources:
+          - all.yaml
+          patchesStrategicMerge:
+          - rancher-workarounds.yaml
+          KUSTOMIZE
+
+          cat >"$workdir/rancher-workarounds.yaml" <<'PATCH'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: rancher
+          spec:
+            progressDeadlineSeconds: 3600
+            template:
+              spec:
+                initContainers:
+                - name: rancher-jailer-patch
+                  image: rancher/rancher:__RANCHER_IMAGE_TAG__
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - /bin/sh
+                  - -ec
+                  args:
+                  - |
+                    sed -e 's/cp -r -l /cp -r /g' -e 's/cp -l /cp /g' /usr/bin/jailer.sh > /patched/jailer.sh
+                    chmod 0755 /patched/jailer.sh
+                    echo "patched /usr/bin/jailer.sh created"
+                    grep -nE 'cp[[:space:]]+(-r[[:space:]]+)?-?l|cp[[:space:]]+-r|cp[[:space:]]+' /patched/jailer.sh | head -40 || true
+                  volumeMounts:
+                  - name: rancher-jailer-script
+                    mountPath: /patched
+                containers:
+                - name: rancher
+                  env:
+                  - name: CATTLE_SYSTEM_CATALOG
+                    value: bundled
+                  - name: CURL_CA_BUNDLE
+                    value: /etc/rancher/ssl/ca-additional.pem
+                  - name: SSL_CERT_FILE
+                    value: /etc/rancher/ssl/ca-additional.pem
+                  volumeMounts:
+                  - name: rancher-jailer-script
+                    mountPath: /usr/bin/jailer.sh
+                    subPath: jailer.sh
+                    readOnly: true
+                  - name: rancher-jail
+                    mountPath: /opt/jail
+                  - name: tls-ca-additional-volume
+                    mountPath: /etc/rancher/ssl/ca-additional.pem
+                    subPath: ca-additional.pem
+                    readOnly: true
+                  - name: tls-ca-additional-volume
+                    mountPath: /etc/pki/trust/anchors/ca-additional.pem
+                    subPath: ca-additional.pem
+                    readOnly: true
+                volumes:
+                - name: rancher-jailer-script
+                  emptyDir: {}
+                - name: rancher-jail
+                  emptyDir:
+                    medium: Memory
+                    sizeLimit: 1Gi
+                - name: tls-ca-additional-volume
+                  secret:
+                    secretName: tls-ca-additional
+                    optional: false
+          PATCH
+
+          sed -i "s/__RANCHER_IMAGE_TAG__/$RANCHER_IMAGE_TAG/g" "$workdir/rancher-workarounds.yaml"
+          kubectl kustomize "$workdir"
+          POST_RENDERER
+
+            chmod 0700 "$post_renderer"
+          }
+
+          start_rancher_image_prepull() {
+            if [ "$rancher_prepull" != "true" ]; then
+              return 0
+            fi
+
+            log_step "Pre-pull Rancher image on schedulable nodes"
+            kubectl -n "$rancher_namespace" apply -f - <<EOF
+          apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: rancher-image-prepull
+            labels:
+              app: rancher-image-prepull
+          spec:
+            selector:
+              matchLabels:
+                app: rancher-image-prepull
+            template:
+              metadata:
+                labels:
+                  app: rancher-image-prepull
+              spec:
+                terminationGracePeriodSeconds: 1
+                containers:
+                - name: prepull
+                  image: rancher/rancher:$rancher_image_tag
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - /bin/sh
+                  - -ec
+                  - sleep 1800
+          EOF
+          }
+
+          wait_rancher_stable() {
+            stable=0
+            last_restarts=""
+            interval=15
+
+            log_step "Wait for Rancher to remain Ready for $rancher_stable_seconds seconds"
+            while [ "$stable" -lt "$rancher_stable_seconds" ]; do
+              pod_line="$(
+                kubectl -n "$rancher_namespace" get pods -l app=rancher \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.status.containerStatuses[?(@.name=="rancher")].ready}{" "}{.status.containerStatuses[?(@.name=="rancher")].restartCount}{"\n"}{end}' \
+                  | head -1
+              )"
+              set -- $pod_line none none none none
+              pod_name="$1"
+              pod_phase="$2"
+              pod_ready="$3"
+              pod_restarts="$4"
+
+              if [ "$pod_phase" = "Running" ] && [ "$pod_ready" = "true" ]; then
+                if [ "$pod_restarts" = "$last_restarts" ]; then
+                  stable=$((stable + interval))
+                else
+                  stable=0
+                  last_restarts="$pod_restarts"
+                fi
+                printf 'Rancher ready: pod=%s restarts=%s stable=%ss/%ss\n' \
+                  "$pod_name" "$pod_restarts" "$stable" "$rancher_stable_seconds"
+              else
+                stable=0
+                last_restarts="$pod_restarts"
+                [ -n "$pod_name" ] || pod_name="none"
+                [ -n "$pod_phase" ] || pod_phase="none"
+                [ -n "$pod_ready" ] || pod_ready="none"
+                [ -n "$pod_restarts" ] || pod_restarts="none"
+                printf 'Rancher not stable yet: pod=%s phase=%s ready=%s restarts=%s\n' \
+                  "$pod_name" "$pod_phase" "$pod_ready" "$pod_restarts"
+              fi
+
+              sleep "$interval"
+            done
+          }
+
+          wait_https_ok() {
+            log_step "Wait for Rancher HTTPS endpoint"
+            for attempt in $(seq 1 80); do
+              http_code="$(curl -kIs -o /dev/null -w '%{http_code}' --max-time 15 "https://$rancher_hostname" 2>/dev/null || true)"
+              if [ "$http_code" = "200" ]; then
+                curl -kIs --max-time 15 "https://$rancher_hostname" | sed -n '1,12p'
+                return 0
+              fi
+              [ -n "$http_code" ] || http_code="curl_failed"
+              echo "HTTPS not ready yet: HTTP $http_code"
+              sleep 15
+            done
+
+            echo "ERROR: Rancher HTTPS endpoint did not return HTTP 200" >&2
+            return 1
+          }
+
+          require_cmd kubectl
+          require_cmd helm
+          require_cmd openssl
+          require_cmd curl
+          kubectl kustomize --help >/dev/null 2>&1 || {
+            echo "ERROR: kubectl kustomize is required for Helm post-rendering" >&2
+            exit 2
+          }
+          if [ ! -r "$ca_bundle_source" ]; then
+            echo "ERROR: CA bundle is not readable: $ca_bundle_source" >&2
+            exit 2
+          fi
+
+          log_step "Helm repositories"
+          helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+          helm repo add "$rancher_chart_repo_name" "$rancher_chart_repo_url" --force-update >/dev/null
+          helm repo update >/dev/null
+
+          log_step "Namespaces"
+          kubectl create namespace "$cert_manager_namespace" --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create namespace "$rancher_namespace" --dry-run=client -o yaml | kubectl apply -f -
+
+          log_step "Install or update cert-manager"
+          helm upgrade --install cert-manager jetstack/cert-manager \
+            --namespace "$cert_manager_namespace" \
+            --version "$cert_manager_version" \
+            --set crds.enabled=true \
+            --wait \
+            --timeout "$wait_timeout"
+
+          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager --timeout="$wait_timeout"
+          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager-webhook --timeout="$wait_timeout"
+          kubectl -n "$cert_manager_namespace" rollout status deploy/cert-manager-cainjector --timeout="$wait_timeout"
+
+          start_rancher_image_prepull
+
+          log_step "Additional CA secret for Rancher"
+          kubectl -n "$rancher_namespace" create secret generic tls-ca-additional \
+            --from-file=ca-additional.pem="$ca_bundle_source" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          log_step "Install Rancher Helm release"
+          write_rancher_values_file
+          export RANCHER_IMAGE_TAG="$rancher_image_tag"
+          write_rancher_post_renderer
+
+          if [ "$rancher_prepull" = "true" ]; then
+            kubectl -n "$rancher_namespace" rollout status daemonset/rancher-image-prepull --timeout="$wait_timeout" || true
+          fi
+
+          helm upgrade --install rancher "$rancher_chart_repo_name/rancher" \
+            --namespace "$rancher_namespace" \
+            --version "$rancher_version" \
+            -f "$values_file" \
+            --post-renderer "$post_renderer" \
+            --wait=false \
+            --timeout "$wait_timeout"
+
+          log_step "Stop stale Rancher ReplicaSets without the jailer patch"
+          while read -r rs; do
+            [ -n "$rs" ] || continue
+            init_names="$(kubectl -n "$rancher_namespace" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[*].name}' 2>/dev/null || true)"
+            init_image="$(kubectl -n "$rancher_namespace" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[?(@.name=="rancher-jailer-patch")].image}' 2>/dev/null || true)"
+            case "$init_names" in
+              *rancher-jailer-patch*) has_jailer_patch="true" ;;
+              *) has_jailer_patch="false" ;;
+            esac
+            if [ "$has_jailer_patch" != "true" ] || [ "$init_image" != "rancher/rancher:$rancher_image_tag" ]; then
+              echo "Scaling stale or incorrectly patched $rs to 0"
+              kubectl -n "$rancher_namespace" scale "$rs" --replicas=0
+            else
+              echo "Keeping patched $rs"
+            fi
+          done <<EOF
+          $(kubectl -n "$rancher_namespace" get rs -l app=rancher -o name)
+          EOF
+
+          log_step "Wait for Rancher"
+          kubectl -n "$rancher_namespace" rollout status deployment/rancher --timeout="$wait_timeout" || {
+            echo "Rancher did not become Ready. Recent status and logs follow." >&2
+            kubectl -n "$rancher_namespace" get deploy,rs,pods,svc,ingress -l app=rancher -o wide >&2 || true
+            kubectl -n "$rancher_namespace" logs -l app=rancher --all-containers --tail=250 --prefix >&2 || true
+            exit 1
+          }
+
+          kubectl -n "$rancher_namespace" get deploy,rs,pods,svc,ingress -l app=rancher -o wide
+          kubectl -n "$rancher_namespace" get issuer,certificate,certificaterequest 2>/dev/null || true
+
+          wait_rancher_stable
+
+          log_step "Wait for Rancher ingress certificate"
+          kubectl -n "$rancher_namespace" wait --for=condition=Ready issuer/rancher --timeout="$wait_timeout"
+          kubectl -n "$rancher_namespace" wait --for=condition=Ready certificate/tls-rancher-ingress --timeout="$wait_timeout"
+
+          wait_https_ok
       - message.email.send:
           to: "${user.email}"
           subject: Rancher Platform Successfully Installed in ${env.name}

--- a/manifest.jps
+++ b/manifest.jps
@@ -353,7 +353,7 @@ actions:
       while [[ $(kubectl -n ingress-traefik get pods -l app.kubernetes.io/name=ingress-traefik,app.kubernetes.io/component=controller -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True"* ]]; do sleep 5; done
 
   install-components:
-    - cmd[${nodes.k8sm.master.id}]: /usr/local/sbin/install-components.sh --base-url=$(echo '${baseUrl}' | base64 -w 0) --admin-account=true --metallb=true --metrics-server=true --dashboard=${settings.dashboard:none} --ingress-name=${globals.ingress-dir}
+    - cmd[${nodes.k8sm.master.id}]: /usr/local/sbin/install-components.sh --base-url=$(echo '${baseUrl}' | base64 -w 0) --admin-account=true --metallb=true --metrics-server=true --dashboard=${settings.dashboard:none} --ingress-name=${globals.ingress-dir} --env-domain=${env.domain}
 
   install-helm-main:
     cmd[${nodes.k8sm.master.id}]: |-
@@ -379,7 +379,12 @@ actions:
     - if ('${settings.deploy}' == 'cc'):
         cmd[${nodes.k8sm.master.id}]: |-
           kubectl apply -f ${baseUrl}/addons/helloworld.yaml
-          while true; do kubectl apply -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/helloworld-ingress.yaml && break; sleep 5; done
+          while true; do
+            wget "${baseUrl}/addons/ingress/${globals.ingress-dir}/helloworld-ingress.yaml" -O /tmp/helloworld-ingress.yaml
+            sed -i 's/example\.com/${env.domain}/g' /tmp/helloworld-ingress.yaml
+            kubectl apply -f /tmp/helloworld-ingress.yaml && break
+            sleep 5
+          done
     - elif ('${settings.deploy}' == 'cmd'):
         cmd[${nodes.k8sm.master.id}]: |-
           ${settings.cmd}
@@ -440,9 +445,14 @@ actions:
   - log: 'api: ${this}'
   - cmd[${nodes.k8sm.master.id}]: |-
       if [ "${this}" == "true" ]; then
-        while true; do kubectl apply -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/api-ingress.yaml && break; sleep 5; done
+        while true; do
+          wget "${baseUrl}/addons/ingress/${globals.ingress-dir}/api-ingress.yaml" -O /tmp/api-ingress.yaml
+          sed -i 's/example\.com/${env.domain}/g' /tmp/api-ingress.yaml
+          kubectl apply -f /tmp/api-ingress.yaml && break
+          sleep 5
+        done
       else
-        kubectl delete -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/api-ingress.yaml
+        kubectl delete ingress kubernetes-api -n default --ignore-not-found
       fi
   - if (${settings.api:true}):
       - setGlobals:
@@ -452,8 +462,8 @@ actions:
   - cmd[${nodes.k8sm.master.id}]: kubectl get secret --namespace kubernetes-monitoring monitoring-grafana &>/dev/null && echo "true" || echo "false"
   - set:
       monitoring_installed: ${response.out}
+  - init-globals-ingress
   - if ('${this.monitoring_installed}' == 'false'):
-      - init-globals-ingress
       - cmd[${nodes.k8sm.master.id}]: |-
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
@@ -469,9 +479,6 @@ actions:
           grafana_secret=$(kubectl get secret --namespace kubernetes-monitoring monitoring-grafana -o jsonpath='{.data.admin-password}' | base64 --decode ; echo)
           [ "${globals.ingress-dir}" == "haproxy" ] && crypt_params="admin=$(openssl passwd -1 ${grafana_secret})" || crypt_params="auth=admin:$(openssl passwd -apr1 ${grafana_secret})"
           kubectl create secret generic --namespace=kubernetes-monitoring monitoring-prometheus --from-literal=${crypt_params}
-          kubectl create -f ${baseUrl}/addons/monitoring/${globals.ingress-dir}/prometheus-ingress.yaml
-          kubectl create -f ${baseUrl}/addons/monitoring/${globals.ingress-dir}/alert-ingress.yaml
-          kubectl create -f ${baseUrl}/addons/monitoring/${globals.ingress-dir}/grafana-ingress.yaml
           for i in {1..10}; do
             sleep 10
             echo "Attempt ${i} of Grafana dashboard parameters setting"
@@ -481,6 +488,12 @@ actions:
             curl -X POST -f -b grafana/grafana-jar.txt "http://${env.domain}/grafana/api/user/stars/dashboard/${dash_id}" || continue
             curl -X PUT -f -H 'Content-Type: application/json' -b grafana/grafana-jar.txt -d "{\"homeDashboardId\":${dash_id}}" "http://${env.domain}/grafana/api/org/preferences" && break || continue
           done
+  - cmd[${nodes.k8sm.master.id}]: |-
+      for ingress_name in prometheus alert grafana; do
+        wget "${baseUrl}/addons/monitoring/${globals.ingress-dir}/${ingress_name}-ingress.yaml" -O "/tmp/${ingress_name}-ingress.yaml"
+        sed -i 's/example\.com/${env.domain}/g' "/tmp/${ingress_name}-ingress.yaml"
+        kubectl apply -f "/tmp/${ingress_name}-ingress.yaml"
+      done
   - cmd[${nodes.k8sm.master.id}]: kubectl get secret --namespace kubernetes-monitoring monitoring-grafana -o jsonpath='{.data.admin-password}' | base64 --decode
   - set:
       grafana_secret: ${response.out}
@@ -1031,7 +1044,7 @@ addons:
             type: warning
             message: Rancher Platforms requires 'nginx' ingress controller! The current ingress controller is '${globals.ingress-dir}'
       - cmd[${nodes.k8sm.master.id}]: |-
-          kubectl delete -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/helloworld-ingress.yaml ||:
+          kubectl delete ingress helloworld -n default --ignore-not-found ||:
           kubectl delete -f ${baseUrl}/addons/helloworld.yaml ||:
       - cmd[${nodes.k8sm.master.id}]: |-
           kubectl get ingress -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{range .spec.rules[*]}{.host}{" "}{range .http.paths[*]}{.path}{"\n"}{end}{end}{end}' |

--- a/manifest.jps
+++ b/manifest.jps
@@ -519,8 +519,8 @@ actions:
   - cmd[${nodes.k8sm.master.id}]: kubectl get secret observability-jaeger-plain --namespace=observability &>/dev/null && echo "true" || echo "false"
   - set:
       jaeger_installed: ${response.out}
+  - init-globals-ingress
   - if ('${this.jaeger_installed}' == 'false'):
-      - init-globals-ingress
       - cmd[${nodes.k8sm.master.id}]: kubectl -n cert-manager get deployment cert-manager &>/dev/null && echo "true" || echo "false"
       - if ('${response.out}' == 'false'):
           - install-cert-manager
@@ -533,8 +533,11 @@ actions:
           kubectl create secret generic --namespace=observability observability-jaeger-plain --from-literal=auth="${jaeger_secret}"
           kubectl create secret generic --namespace=observability observability-jaeger --from-literal=${crypt_params}
           kubectl apply -f ${baseUrl}/addons/jaeger/jelastic-jaeger.yaml
-          kubectl apply -f ${baseUrl}/addons/ingress/${globals.ingress-dir}/jaeger-ingress.yaml
           wait-deployment.sh jaeger observability 1 720
+  - cmd[${nodes.k8sm.master.id}]: |-
+      wget "${baseUrl}/addons/ingress/${globals.ingress-dir}/jaeger-ingress.yaml" -O /tmp/jaeger-ingress.yaml
+      sed -i 's/example\.com/${env.domain}/g' /tmp/jaeger-ingress.yaml
+      kubectl apply -f /tmp/jaeger-ingress.yaml
   - cmd[${nodes.k8sm.master.id}]: kubectl get secret --namespace=observability observability-jaeger-plain -o jsonpath='{.data.auth}' | base64 --decode
   - set:
       jaeger_secret: ${response.out}

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes-release
-baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.
@@ -580,7 +580,7 @@ addons:
   - id: conf-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Configuration
     description: Configure remote API access and install complementary tools
     logo: /images/k8s-config.png
@@ -741,7 +741,7 @@ addons:
   - id: monitor-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Monitoring
     description: Install cluster monitoring components (Prometheus and Grafana)
     logo: /images/k8s-monitor.png
@@ -766,7 +766,7 @@ addons:
   - id: upgrade-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Cluster Upgrade
     description: Upgrade Kubernetes cluster to a newer version
     logo: /images/k8s-upgrade.png
@@ -981,7 +981,7 @@ addons:
   - id: certman-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Certificate Manager
     description: |
       Kubernetes SSL Certificate Manager allows to bind custom domain names
@@ -1025,7 +1025,7 @@ addons:
   - id: rancher-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: Rancher Installer
     description: Rancher Management Platform
     logo: /images/k8s-rancher.png
@@ -1118,7 +1118,7 @@ addons:
   - id: regcreds-k8s-addon
     type: update
     permanent: true
-    baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14
+    baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14
     name: DockerHub Registry Credentials
     description: |
       Leverage DockerHub images pull rate limits: assign DockerHub user credentials to Kubernetes deployments cluster-wide

--- a/manifest.jps
+++ b/manifest.jps
@@ -1057,6 +1057,20 @@ addons:
       - set:
           rancher_existing: ${response.out}
       - if ('${this.rancher_existing}' != 'true'):
+          - cmd[${nodes.k8sm.master.id}]: |-
+              http_code=$(curl -Lks -o /dev/null -w "%{http_code}" "${env.url}")
+              ret_code=$?
+              if [ ${ret_code} -ne 0 ]; then
+                echo "An error occurred while accessing the [endpoint](${env.url})"
+              elif [ ${http_code} -eq 200 ]; then
+                echo "The [endpoint](${env.url}) is already taken"
+              elif [ ${http_code} -ne 404 ]; then
+                echo "The [endpoint](${env.url}) is present and answered with HTTP code ${http_code}"
+              fi
+          - if ('${response.out}'):
+              return:
+                type: warning
+                message: Cannot deploy Rancher UI! ${response.out}.
           - cmd[${nodes.k8sm.master.id}]: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
           - set:
               rancher_secret: ${response.out}

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0; i < quotas.length; i++){
     }
 }
 var resp = {result:0};
-var url = "https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.9/configs/settings.yaml";
+var url = "https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0; i < quotas.length; i++){
     }
 }
 var resp = {result:0};
-var url = "https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14/configs/settings.yaml";
+var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0; i < quotas.length; i++){
     }
 }
 var resp = {result:0};
-var url = "https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/configs/settings.yaml";
+var url = "https://cdn.jsdelivr.net/gh/xzkutor/kubernetes@v1.29.14/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0; i < quotas.length; i++){
     }
 }
 var resp = {result:0};
-var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/v1.29.14/configs/settings.yaml";
+var url = "https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@v1.29.14/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/install-components.sh
+++ b/scripts/install-components.sh
@@ -69,8 +69,8 @@ if [ -z "${BASE_URL}" ]; then
 fi
 
 if [ -n "${DASHBOARD}" ] && [ -n "${INGRESS_NAME}" ] && [ -z "${ENV_DOMAIN}" ]; then
-	echo -e "Missing mandatory argument --env-domain=<domain>"
-	exit 1
+	ENV_DOMAIN="$((hostname -f 2>/dev/null || hostname 2>/dev/null || true) | sed -E 's/^[^-]+-//')"
+	echo "$(date): --env-domain was not provided, using detected domain '${ENV_DOMAIN}'"
 fi
 
 apply_env_ingress() {

--- a/scripts/install-components.sh
+++ b/scripts/install-components.sh
@@ -5,7 +5,7 @@
 METALLB_VER="0.14.8"
 
 HELP="Usage:
-	$0 --base-url=<base64-encoded-url> --admin-account=(true|false) --metallb=(true|false) --metrics-server=(true|false) --dashboard=(general|skooner) --ingress-name=<ingress-controller>
+	$0 --base-url=<base64-encoded-url> --admin-account=(true|false) --metallb=(true|false) --metrics-server=(true|false) --dashboard=(general|skooner) --ingress-name=<ingress-controller> --env-domain=<domain>
 Options:
 	--base-url=         manifest baseUrl
 	--admin-account=    setup admin account
@@ -13,6 +13,7 @@ Options:
 	--metrics-server=   install metrics-server
 	--dashboard=        install kubernetes-dashboard
 	--ingress-name=     ingress controller used
+	--env-domain=       environment domain for host-specific ingress rules
 	-h, --help          show this help
 "
 if [[ $# -eq 0 ]] ; then
@@ -46,6 +47,10 @@ for key in "$@"; do
 		INGRESS_NAME="${key#*=}"
 		shift
 		;;
+	--env-domain=*)
+		ENV_DOMAIN="${key#*=}"
+		shift
+		;;
 	-h | --help)
 		echo -e "${HELP}"
 		exit 1
@@ -62,6 +67,27 @@ if [ -z "${BASE_URL}" ]; then
 	echo -e "Missing mandatory argument --base-url=<base64-encoded-url>"
 	exit 1
 fi
+
+if [ -n "${DASHBOARD}" ] && [ -n "${INGRESS_NAME}" ] && [ -z "${ENV_DOMAIN}" ]; then
+	echo -e "Missing mandatory argument --env-domain=<domain>"
+	exit 1
+fi
+
+apply_env_ingress() {
+	local source_url="${1}"
+	local manifest_file
+
+	manifest_file="$(mktemp)"
+	wget -q "${source_url}" -O "${manifest_file}" || {
+		rm -f "${manifest_file}"
+		return 1
+	}
+	sed -i "s/example\\.com/${ENV_DOMAIN}/g" "${manifest_file}"
+	kubectl apply -f "${manifest_file}"
+	local result=$?
+	rm -f "${manifest_file}"
+	return ${result}
+}
 
 ( ( echo "$(date): --- install components started";
 
@@ -99,11 +125,11 @@ fi
 		case "${DASHBOARD}" in
 		general)
 			kubectl create -f "${BASE_URL}/addons/kubernetes-dashboard.yaml";
-			while true; do kubectl create -f "${BASE_URL}/addons/ingress/${INGRESS_NAME}/dashboard-ingress.yaml" && break; sleep 5; done;
+			while true; do apply_env_ingress "${BASE_URL}/addons/ingress/${INGRESS_NAME}/dashboard-ingress.yaml" && break; sleep 5; done;
 		;;
 		skooner|k8dash)
 			kubectl apply -f "${BASE_URL}/addons/kubernetes-skooner.yaml";
-			while true; do kubectl apply -f "${BASE_URL}/addons/ingress/${INGRESS_NAME}/skooner-ingress.yaml" && break; sleep 5; done;
+			while true; do apply_env_ingress "${BASE_URL}/addons/ingress/${INGRESS_NAME}/skooner-ingress.yaml" && break; sleep 5; done;
 		;;
 		*)
 			echo "$(date): unknown kubernetes-dashboard version '${DASHBOARD}', skipped"

--- a/scripts/install-rancher-2.10.3-workarounds.sh
+++ b/scripts/install-rancher-2.10.3-workarounds.sh
@@ -231,6 +231,39 @@ spec:
 EOF
 }
 
+refresh_tls_ca_secret() {
+  local ca_data get_error get_rc patch_file
+
+  get_error="$(mktemp)"
+  patch_file="$(mktemp)"
+  TMP_FILES+=("$get_error" "$patch_file")
+
+  if kubectl -n "$RANCHER_NAMESPACE" get secret tls-ca-additional >/dev/null 2>"$get_error"; then
+    ca_data="$(base64 "$CA_BUNDLE_SOURCE" | tr -d '\n')"
+    cat >"$patch_file" <<EOF
+{"data":{"ca-additional.pem":"$ca_data"}}
+EOF
+    if kubectl patch --help 2>/dev/null | grep -q -- '--patch-file'; then
+      kubectl -n "$RANCHER_NAMESPACE" patch secret tls-ca-additional \
+        --type=merge \
+        --patch-file "$patch_file"
+    else
+      kubectl -n "$RANCHER_NAMESPACE" patch secret tls-ca-additional \
+        --type=merge \
+        -p "$(cat "$patch_file")"
+    fi
+  else
+    get_rc=$?
+    if grep -Eqi 'notfound|not found' "$get_error"; then
+      kubectl -n "$RANCHER_NAMESPACE" create secret generic tls-ca-additional \
+        --from-file=ca-additional.pem="$CA_BUNDLE_SOURCE"
+    else
+      cat "$get_error" >&2
+      return "$get_rc"
+    fi
+  fi
+}
+
 wait_rancher_stable() {
   local stable_seconds="$RANCHER_STABLE_SECONDS"
   local interval=15
@@ -331,9 +364,7 @@ kubectl -n "$CERT_MANAGER_NAMESPACE" rollout status deploy/cert-manager-cainject
 start_rancher_image_prepull
 
 log "Additional CA secret for Rancher"
-kubectl -n "$RANCHER_NAMESPACE" create secret generic tls-ca-additional \
-  --from-file=ca-additional.pem="$CA_BUNDLE_SOURCE" \
-  --dry-run=client -o yaml | kubectl apply -f -
+refresh_tls_ca_secret
 
 log "Install or update Rancher Helm release"
 write_rancher_values_file

--- a/scripts/install-rancher-2.10.3-workarounds.sh
+++ b/scripts/install-rancher-2.10.3-workarounds.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Install Rancher v2.10.3 with the startup workarounds needed on Jelastic/K8s
+# v1.29.x clusters where Rancher exits with:
+#   [FATAL] error running the jail command: timed out waiting for the script to complete: signal: killed
+
+RANCHER_VERSION="${RANCHER_VERSION:-2.10.3}"
+RANCHER_IMAGE_TAG="${RANCHER_IMAGE_TAG:-v${RANCHER_VERSION#v}}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.16.2}"
+RANCHER_NAMESPACE="${RANCHER_NAMESPACE:-cattle-system}"
+CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+INGRESS_CLASS_NAME="${INGRESS_CLASS_NAME:-nginx}"
+CA_BUNDLE_SOURCE="${CA_BUNDLE_SOURCE:-/etc/pki/tls/certs/ca-bundle.crt}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-30m}"
+RANCHER_STABLE_SECONDS="${RANCHER_STABLE_SECONDS:-180}"
+RANCHER_PREPULL="${RANCHER_PREPULL:-true}"
+
+TMP_FILES=()
+
+cleanup() {
+  if [[ ${#TMP_FILES[@]} -gt 0 ]]; then
+    rm -f "${TMP_FILES[@]}" 2>/dev/null || true
+  fi
+  if [[ "${RANCHER_PREPULL}" == "true" ]]; then
+    kubectl -n "$RANCHER_NAMESPACE" delete daemonset rancher-image-prepull \
+      --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${RANCHER_HOSTNAME:-}" ]]; then
+  echo "ERROR: set RANCHER_HOSTNAME, for example:" >&2
+  echo "  RANCHER_HOSTNAME=env-1234567.madrid.jele.io $0" >&2
+  exit 2
+fi
+
+if [[ -z "${BOOTSTRAP_PASSWORD:-}" ]]; then
+  if kubectl -n "$RANCHER_NAMESPACE" get secret bootstrap-secret >/dev/null 2>&1; then
+    BOOTSTRAP_PASSWORD="$(
+      kubectl -n "$RANCHER_NAMESPACE" get secret bootstrap-secret \
+        -o jsonpath='{.data.bootstrapPassword}' | base64 -d
+    )"
+    echo "Reusing existing Rancher bootstrap password. It will not be printed."
+  elif [[ -t 0 ]]; then
+    read -r -s -p "Rancher bootstrap password: " BOOTSTRAP_PASSWORD
+    echo
+  fi
+fi
+
+if [[ -z "${BOOTSTRAP_PASSWORD:-}" ]]; then
+  BOOTSTRAP_PASSWORD="$(openssl rand -hex 16)"
+  echo "Generated Rancher bootstrap password. It will not be printed."
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: required command not found: $1" >&2
+    exit 2
+  }
+}
+
+log() {
+  printf '\n== %s ==\n' "$*"
+}
+
+yaml_quote() {
+  local value="$1"
+  value=${value//\'/\'\'}
+  printf "'%s'" "$value"
+}
+
+write_rancher_values_file() {
+  local values_file
+  values_file="$(mktemp)"
+  TMP_FILES+=("$values_file")
+
+  cat >"$values_file" <<EOF
+hostname: $(yaml_quote "$RANCHER_HOSTNAME")
+bootstrapPassword: $(yaml_quote "$BOOTSTRAP_PASSWORD")
+replicas: 1
+ingress:
+  ingressClassName: $(yaml_quote "$INGRESS_CLASS_NAME")
+  tls:
+    source: rancher
+tls: ingress
+additionalTrustedCAs: true
+useBundledSystemChart: true
+startupProbe:
+  failureThreshold: 180
+  periodSeconds: 10
+  timeoutSeconds: 5
+livenessProbe:
+  failureThreshold: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+readinessProbe:
+  failureThreshold: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+extraEnv:
+- name: CURL_CA_BUNDLE
+  value: /etc/rancher/ssl/ca-additional.pem
+- name: SSL_CERT_FILE
+  value: /etc/rancher/ssl/ca-additional.pem
+EOF
+
+  RANCHER_VALUES_FILE="$values_file"
+}
+
+write_rancher_post_renderer() {
+  local post_renderer
+  post_renderer="$(mktemp)"
+  TMP_FILES+=("$post_renderer")
+
+  cat >"$post_renderer" <<EOF
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+workdir=\$(mktemp -d)
+trap 'rm -rf "\$workdir"' EXIT
+
+cat >"\$workdir/all.yaml"
+cat >"\$workdir/kustomization.yaml" <<'KUSTOMIZE'
+resources:
+- all.yaml
+patchesStrategicMerge:
+- rancher-workarounds.yaml
+KUSTOMIZE
+
+cat >"\$workdir/rancher-workarounds.yaml" <<'PATCH'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rancher
+spec:
+  progressDeadlineSeconds: 3600
+  template:
+    spec:
+      initContainers:
+      - name: rancher-jailer-patch
+        image: rancher/rancher:${RANCHER_IMAGE_TAG}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -ec
+        args:
+        - |
+          sed -e 's/cp -r -l /cp -r /g' -e 's/cp -l /cp /g' /usr/bin/jailer.sh > /patched/jailer.sh
+          chmod 0755 /patched/jailer.sh
+          echo "patched /usr/bin/jailer.sh created"
+          grep -nE 'cp[[:space:]]+(-r[[:space:]]+)?-?l|cp[[:space:]]+-r|cp[[:space:]]+' /patched/jailer.sh | head -40 || true
+        volumeMounts:
+        - name: rancher-jailer-script
+          mountPath: /patched
+      containers:
+      - name: rancher
+        env:
+        - name: CATTLE_SYSTEM_CATALOG
+          value: bundled
+        - name: CURL_CA_BUNDLE
+          value: /etc/rancher/ssl/ca-additional.pem
+        - name: SSL_CERT_FILE
+          value: /etc/rancher/ssl/ca-additional.pem
+        volumeMounts:
+        - name: rancher-jailer-script
+          mountPath: /usr/bin/jailer.sh
+          subPath: jailer.sh
+          readOnly: true
+        - name: rancher-jail
+          mountPath: /opt/jail
+        - name: tls-ca-additional-volume
+          mountPath: /etc/rancher/ssl/ca-additional.pem
+          subPath: ca-additional.pem
+          readOnly: true
+        - name: tls-ca-additional-volume
+          mountPath: /etc/pki/trust/anchors/ca-additional.pem
+          subPath: ca-additional.pem
+          readOnly: true
+      volumes:
+      - name: rancher-jailer-script
+        emptyDir: {}
+      - name: rancher-jail
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
+      - name: tls-ca-additional-volume
+        secret:
+          secretName: tls-ca-additional
+          optional: false
+PATCH
+
+kubectl kustomize "\$workdir"
+EOF
+
+  chmod 0700 "$post_renderer"
+  RANCHER_POST_RENDERER="$post_renderer"
+}
+
+start_rancher_image_prepull() {
+  if [[ "${RANCHER_PREPULL}" != "true" ]]; then
+    return 0
+  fi
+
+  log "Pre-pull Rancher image on schedulable nodes"
+  kubectl -n "$RANCHER_NAMESPACE" apply -f - <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rancher-image-prepull
+  labels:
+    app: rancher-image-prepull
+spec:
+  selector:
+    matchLabels:
+      app: rancher-image-prepull
+  template:
+    metadata:
+      labels:
+        app: rancher-image-prepull
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: prepull
+        image: rancher/rancher:${RANCHER_IMAGE_TAG}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -ec
+        - sleep 1800
+EOF
+}
+
+wait_rancher_stable() {
+  local stable_seconds="$RANCHER_STABLE_SECONDS"
+  local interval=15
+  local stable=0
+  local last_restarts=""
+  local pod_line pod_name pod_phase pod_ready pod_restarts
+
+  log "Wait for Rancher to remain Ready for ${stable_seconds}s"
+  while (( stable < stable_seconds )); do
+    pod_line="$(
+      kubectl -n "$RANCHER_NAMESPACE" get pods -l app=rancher \
+        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.status.containerStatuses[?(@.name=="rancher")].ready}{" "}{.status.containerStatuses[?(@.name=="rancher")].restartCount}{"\n"}{end}' \
+        | head -1
+    )"
+    read -r pod_name pod_phase pod_ready pod_restarts _ <<<"${pod_line:-none none none none}"
+    pod_name="${pod_name:-none}"
+    pod_phase="${pod_phase:-none}"
+    pod_ready="${pod_ready:-none}"
+    pod_restarts="${pod_restarts:-none}"
+
+    if [[ "$pod_phase" == "Running" && "$pod_ready" == "true" ]]; then
+      if [[ "$pod_restarts" == "$last_restarts" ]]; then
+        stable=$((stable + interval))
+      else
+        stable=0
+        last_restarts="$pod_restarts"
+      fi
+      printf 'Rancher ready: pod=%s restarts=%s stable=%ss/%ss\n' \
+        "$pod_name" "$pod_restarts" "$stable" "$stable_seconds"
+    else
+      stable=0
+      last_restarts="$pod_restarts"
+      printf 'Rancher not stable yet: pod=%s phase=%s ready=%s restarts=%s\n' \
+        "$pod_name" "$pod_phase" "$pod_ready" "$pod_restarts"
+    fi
+
+    sleep "$interval"
+  done
+}
+
+wait_https_ok() {
+  local code
+
+  log "Wait for Rancher HTTPS endpoint"
+  for _ in $(seq 1 80); do
+    code="$(curl -kIs -o /dev/null -w '%{http_code}' --max-time 15 "https://${RANCHER_HOSTNAME}" 2>/dev/null || true)"
+    if [[ "$code" == "200" ]]; then
+      curl -kIs --max-time 15 "https://${RANCHER_HOSTNAME}" | sed -n '1,12p'
+      return 0
+    fi
+    echo "HTTPS not ready yet: HTTP ${code:-curl_failed}"
+    sleep 15
+  done
+
+  echo "ERROR: Rancher HTTPS endpoint did not return HTTP 200" >&2
+  return 1
+}
+
+require_cmd kubectl
+require_cmd helm
+require_cmd openssl
+require_cmd curl
+kubectl kustomize --help >/dev/null 2>&1 || {
+  echo "ERROR: kubectl kustomize is required for Helm post-rendering" >&2
+  exit 2
+}
+
+if [[ ! -r "$CA_BUNDLE_SOURCE" ]]; then
+  echo "ERROR: CA bundle is not readable: $CA_BUNDLE_SOURCE" >&2
+  exit 2
+fi
+
+log "Cluster context"
+kubectl config current-context
+kubectl get nodes -o wide
+
+log "Helm repositories"
+helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+helm repo add rancher-latest https://releases.rancher.com/server-charts/latest --force-update >/dev/null
+helm repo update >/dev/null
+
+log "Namespaces"
+kubectl create namespace "$CERT_MANAGER_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace "$RANCHER_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+log "Install or update cert-manager"
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace "$CERT_MANAGER_NAMESPACE" \
+  --version "$CERT_MANAGER_VERSION" \
+  --set crds.enabled=true \
+  --wait \
+  --timeout "$WAIT_TIMEOUT"
+
+kubectl -n "$CERT_MANAGER_NAMESPACE" rollout status deploy/cert-manager --timeout="$WAIT_TIMEOUT"
+kubectl -n "$CERT_MANAGER_NAMESPACE" rollout status deploy/cert-manager-webhook --timeout="$WAIT_TIMEOUT"
+kubectl -n "$CERT_MANAGER_NAMESPACE" rollout status deploy/cert-manager-cainjector --timeout="$WAIT_TIMEOUT"
+
+start_rancher_image_prepull
+
+log "Additional CA secret for Rancher"
+kubectl -n "$RANCHER_NAMESPACE" create secret generic tls-ca-additional \
+  --from-file=ca-additional.pem="$CA_BUNDLE_SOURCE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+log "Install or update Rancher Helm release"
+write_rancher_values_file
+write_rancher_post_renderer
+
+if [[ "${RANCHER_PREPULL}" == "true" ]]; then
+  kubectl -n "$RANCHER_NAMESPACE" rollout status daemonset/rancher-image-prepull --timeout="$WAIT_TIMEOUT" || true
+fi
+
+helm upgrade --install rancher rancher-latest/rancher \
+  --namespace "$RANCHER_NAMESPACE" \
+  --version "$RANCHER_VERSION" \
+  -f "$RANCHER_VALUES_FILE" \
+  --post-renderer "$RANCHER_POST_RENDERER" \
+  --wait=false \
+  --timeout "$WAIT_TIMEOUT"
+
+log "Stop stale Rancher ReplicaSets without the jailer patch"
+while read -r rs; do
+  [[ -n "$rs" ]] || continue
+  init_names="$(kubectl -n "$RANCHER_NAMESPACE" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[*].name}' 2>/dev/null || true)"
+  init_image="$(kubectl -n "$RANCHER_NAMESPACE" get "$rs" -o jsonpath='{.spec.template.spec.initContainers[?(@.name=="rancher-jailer-patch")].image}' 2>/dev/null || true)"
+  if [[ "$init_names" != *rancher-jailer-patch* || "$init_image" != "rancher/rancher:${RANCHER_IMAGE_TAG}" ]]; then
+    echo "Scaling stale or incorrectly patched $rs to 0"
+    kubectl -n "$RANCHER_NAMESPACE" scale "$rs" --replicas=0
+  else
+    echo "Keeping patched $rs"
+  fi
+done < <(kubectl -n "$RANCHER_NAMESPACE" get rs -l app=rancher -o name)
+
+log "Wait for Rancher"
+kubectl -n "$RANCHER_NAMESPACE" rollout status deployment/rancher --timeout="$WAIT_TIMEOUT" || {
+  echo "Rancher did not become Ready. Recent status and logs follow." >&2
+  kubectl -n "$RANCHER_NAMESPACE" get deploy,rs,pods,svc,ingress -l app=rancher -o wide >&2 || true
+  kubectl -n "$RANCHER_NAMESPACE" logs -l app=rancher --all-containers --tail=250 --prefix >&2 || true
+  exit 1
+}
+
+log "Rancher status"
+kubectl -n "$RANCHER_NAMESPACE" get deploy,rs,pods,svc,ingress -l app=rancher -o wide
+kubectl -n "$RANCHER_NAMESPACE" get issuer,certificate,certificaterequest 2>/dev/null || true
+
+wait_rancher_stable
+
+log "Wait for Rancher ingress certificate"
+kubectl -n "$RANCHER_NAMESPACE" wait --for=condition=Ready issuer/rancher --timeout="$WAIT_TIMEOUT"
+kubectl -n "$RANCHER_NAMESPACE" wait --for=condition=Ready certificate/tls-rancher-ingress --timeout="$WAIT_TIMEOUT"
+
+wait_https_ok
+
+log "Final Rancher status"
+kubectl -n "$RANCHER_NAMESPACE" get deploy,rs,pods,svc,ingress -l app=rancher -o wide
+kubectl -n "$RANCHER_NAMESPACE" get issuer,certificate,certificaterequest 2>/dev/null || true

--- a/scripts/install-rancher-workarounds.sh
+++ b/scripts/install-rancher-workarounds.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Install Rancher v2.10.3 with the startup workarounds needed on Jelastic/K8s
-# v1.29.x clusters where Rancher exits with:
-#   [FATAL] error running the jail command: timed out waiting for the script to complete: signal: killed
-
+# Rancher addon constants. Change these values to select another supported version.
 RANCHER_VERSION="${RANCHER_VERSION:-2.10.3}"
 RANCHER_IMAGE_TAG="${RANCHER_IMAGE_TAG:-v${RANCHER_VERSION#v}}"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.16.2}"
+RANCHER_CHART_REPO_NAME="${RANCHER_CHART_REPO_NAME:-rancher-latest}"
+RANCHER_CHART_REPO_URL="${RANCHER_CHART_REPO_URL:-https://releases.rancher.com/server-charts/latest}"
 RANCHER_NAMESPACE="${RANCHER_NAMESPACE:-cattle-system}"
 CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
 INGRESS_CLASS_NAME="${INGRESS_CLASS_NAME:-nginx}"
@@ -15,6 +14,8 @@ CA_BUNDLE_SOURCE="${CA_BUNDLE_SOURCE:-/etc/pki/tls/certs/ca-bundle.crt}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-30m}"
 RANCHER_STABLE_SECONDS="${RANCHER_STABLE_SECONDS:-180}"
 RANCHER_PREPULL="${RANCHER_PREPULL:-true}"
+RANCHER_PUBLIC_HTTPS_CHECK="${RANCHER_PUBLIC_HTTPS_CHECK:-true}"
+RANCHER_REQUIRE_PUBLIC_HTTPS="${RANCHER_REQUIRE_PUBLIC_HTTPS:-false}"
 
 TMP_FILES=()
 
@@ -30,8 +31,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ -z "${RANCHER_HOSTNAME:-}" ]]; then
-  echo "ERROR: set RANCHER_HOSTNAME, for example:" >&2
-  echo "  RANCHER_HOSTNAME=env-1234567.madrid.jele.io $0" >&2
+  echo "ERROR: RANCHER_HOSTNAME is required" >&2
   exit 2
 fi
 
@@ -68,6 +68,17 @@ yaml_quote() {
   local value="$1"
   value=${value//\'/\'\'}
   printf "'%s'" "$value"
+}
+
+duration_seconds() {
+  local value="$1"
+
+  case "$value" in
+    *h) echo $((${value%h} * 3600)) ;;
+    *m) echo $((${value%m} * 60)) ;;
+    *s) echo "${value%s}" ;;
+    *) echo "$value" ;;
+  esac
 }
 
 write_rancher_values_file() {
@@ -266,13 +277,25 @@ EOF
 
 wait_rancher_stable() {
   local stable_seconds="$RANCHER_STABLE_SECONDS"
+  local deadline_seconds
   local interval=15
   local stable=0
   local last_restarts=""
   local pod_line pod_name pod_phase pod_ready pod_restarts
+  local started_at
+
+  deadline_seconds="$(duration_seconds "$WAIT_TIMEOUT")"
+  started_at="$(date +%s)"
 
   log "Wait for Rancher to remain Ready for ${stable_seconds}s"
   while (( stable < stable_seconds )); do
+    if (( $(date +%s) - started_at >= deadline_seconds )); then
+      echo "ERROR: Rancher did not remain Ready for ${stable_seconds}s before timeout ${WAIT_TIMEOUT}" >&2
+      kubectl -n "$RANCHER_NAMESPACE" get deploy,rs,pods,svc,ingress -l app=rancher -o wide >&2 || true
+      kubectl -n "$RANCHER_NAMESPACE" logs -l app=rancher --all-containers --tail=250 --prefix >&2 || true
+      return 1
+    fi
+
     pod_line="$(
       kubectl -n "$RANCHER_NAMESPACE" get pods -l app=rancher \
         -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.status.containerStatuses[?(@.name=="rancher")].ready}{" "}{.status.containerStatuses[?(@.name=="rancher")].restartCount}{"\n"}{end}' \
@@ -307,10 +330,15 @@ wait_rancher_stable() {
 wait_https_ok() {
   local code
 
+  if [[ "$RANCHER_PUBLIC_HTTPS_CHECK" != "true" ]]; then
+    log "Skip Rancher public HTTPS endpoint check"
+    return 0
+  fi
+
   log "Wait for Rancher HTTPS endpoint"
   for _ in $(seq 1 80); do
     code="$(curl -kIs -o /dev/null -w '%{http_code}' --max-time 15 "https://${RANCHER_HOSTNAME}" 2>/dev/null || true)"
-    if [[ "$code" == "200" ]]; then
+    if [[ "$code" =~ ^(200|30[1278])$ ]]; then
       curl -kIs --max-time 15 "https://${RANCHER_HOSTNAME}" | sed -n '1,12p'
       return 0
     fi
@@ -318,8 +346,13 @@ wait_https_ok() {
     sleep 15
   done
 
-  echo "ERROR: Rancher HTTPS endpoint did not return HTTP 200" >&2
-  return 1
+  if [[ "$RANCHER_REQUIRE_PUBLIC_HTTPS" == "true" ]]; then
+    echo "ERROR: Rancher HTTPS endpoint did not return HTTP 200/3xx" >&2
+    return 1
+  fi
+
+  echo "WARNING: Rancher public HTTPS endpoint did not return HTTP 200/3xx from this node; continuing because deployment, ingress, and certificate checks passed." >&2
+  return 0
 }
 
 require_cmd kubectl
@@ -336,13 +369,9 @@ if [[ ! -r "$CA_BUNDLE_SOURCE" ]]; then
   exit 2
 fi
 
-log "Cluster context"
-kubectl config current-context
-kubectl get nodes -o wide
-
 log "Helm repositories"
 helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest --force-update >/dev/null
+helm repo add "$RANCHER_CHART_REPO_NAME" "$RANCHER_CHART_REPO_URL" --force-update >/dev/null
 helm repo update >/dev/null
 
 log "Namespaces"
@@ -374,7 +403,7 @@ if [[ "${RANCHER_PREPULL}" == "true" ]]; then
   kubectl -n "$RANCHER_NAMESPACE" rollout status daemonset/rancher-image-prepull --timeout="$WAIT_TIMEOUT" || true
 fi
 
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher "$RANCHER_CHART_REPO_NAME/rancher" \
   --namespace "$RANCHER_NAMESPACE" \
   --version "$RANCHER_VERSION" \
   -f "$RANCHER_VALUES_FILE" \


### PR DESCRIPTION
This pull request updates the ingress configuration for multiple services and ingress controllers (HAProxy, NGINX, Traefik) to explicitly specify the `host` field as `example.com` in all relevant ingress rules. Additionally, it updates the Jaeger CRs to include an ingress section with host and class, and corrects the Prometheus HAProxy ingress to use the correct path rewrite and class. These changes help standardize and clarify ingress routing across the stack.

**Ingress rule standardization:**

* Added `host: example.com` to all ingress rules for HAProxy, NGINX, and Traefik across API, dashboard, helloworld, skooner, alert, grafana, and prometheus services to ensure explicit host-based routing. [[1]](diffhunk://#diff-c161ff04472e6d3914c4477685c5c27c0a115d78672a4fc4f73acf76be11a66fL14-R15) [[2]](diffhunk://#diff-de8b8b2da5f57f0b2dc62f494d935b8d8c8652ff0ec39e1ef4ef1e835c43a359L13-R14) [[3]](diffhunk://#diff-02033c75b9215ab5de5dbc5ae390084a9f40cd9b7d60ee7be346573dad80fb1dL9-R10) [[4]](diffhunk://#diff-e0ccf9695489410e11c55c832f967a3d88b8a2efb672dad200e129b98c20ad14L11-R12) [[5]](diffhunk://#diff-be4ee57291a9443387c120e193573cf9c6f572d9855d55805fe4c284c36ff506L15-R16) [[6]](diffhunk://#diff-6ea6ddbf8d9714af08e85d0e86de8725168bb0494fa2122208d8865edc079c06L16-R17) [[7]](diffhunk://#diff-99c71695df4049665cec5f4e86d1ee55ff9c78b13458db4f985c8983bb080d23L11-R12) [[8]](diffhunk://#diff-f5c48c1decc6824377cc37f877dfe00fd154245350abda5333e5ebec8ed17b01L14-R15) [[9]](diffhunk://#diff-340a3a2854a6b04906db2a7f6174b4f8c76fc6dbc7a00615cd16c0df6dc7258dL12-R13) [[10]](diffhunk://#diff-9bb13879314ef0b59439dd0732605e86b8233f33a577937ebb779a7abaecceabL12-R13) [[11]](diffhunk://#diff-f0f778fafcd33bfed12c3b2f90540bf6821f150c44f61d471f2969ce373f1f69L10-R11) [[12]](diffhunk://#diff-64e4c0bbcb0474b58857aef090d6a43328f7bb3684814606a8ec4b4b80711d0cL12-R13) [[13]](diffhunk://#diff-a91bb387178218caf4438735124b0c6a98917516a42e2f2247055559a34c884dL14-R15) [[14]](diffhunk://#diff-79a7bc958fc73db5ebbc2d90f4c656ba172546e82099c4fe4080b8d3b67157d7L12-R13) [[15]](diffhunk://#diff-c16537df7ddc11777dd853f67f0814564304e0f98bcadc09e8cbdd9a489253e5L16-R17) [[16]](diffhunk://#diff-c904ae0292a30becd4b9f9492562a6215b2a6836f6743bb344c9dd82a3a3ae45L14-R15)

**Jaeger ingress configuration:**

* Added an `ingress` section to the Jaeger CRs for HAProxy, NGINX, and Traefik, specifying `hosts: [example.com]` and the appropriate `ingressClassName` for each. [[1]](diffhunk://#diff-8c7b797139169e88fc70d03a03fb057ab20f13f1e146d516c626f7f0bc836dd8R7-R10) [[2]](diffhunk://#diff-10be26a0155059a35e5651c5fc1430e3fcc43e422d308c81b69d76f8fb681feeR7-R10) [[3]](diffhunk://#diff-16da836cda7483ef2e0868fe95e33f3b29b620679871cde6f07352f0386a6193R8-R11)

**Prometheus HAProxy ingress fix:**

* Corrected the Prometheus HAProxy ingress to use the right path rewrite (`/prometheus(/|$)(.*) /`) and set `ingressClassName` to `haproxy` instead of `nginx`.

These updates improve clarity and maintainability of ingress configurations, and ensure consistent, host-based routing for all exposed services.This pull request standardizes Ingress resource definitions across multiple addons by explicitly specifying the `host` field (set to `example.com`) for all ingress rules. Additionally, it updates Jaeger ingress configurations to use a nested `ingress` field with `hosts` and `ingressClassName`, and corrects the Prometheus ingress configuration for HAProxy. These changes improve clarity, consistency, and maintainability of ingress configurations.

**Ingress resource standardization:**

* All Ingress resources for HAProxy, NGINX, and Traefik now explicitly specify a `host` field set to `example.com` in their `rules` sections, ensuring consistent routing and easier customization. [[1]](diffhunk://#diff-c161ff04472e6d3914c4477685c5c27c0a115d78672a4fc4f73acf76be11a66fL14-R15) [[2]](diffhunk://#diff-de8b8b2da5f57f0b2dc62f494d935b8d8c8652ff0ec39e1ef4ef1e835c43a359L13-R14) [[3]](diffhunk://#diff-02033c75b9215ab5de5dbc5ae390084a9f40cd9b7d60ee7be346573dad80fb1dL9-R10) [[4]](diffhunk://#diff-e0ccf9695489410e11c55c832f967a3d88b8a2efb672dad200e129b98c20ad14L11-R12) [[5]](diffhunk://#diff-be4ee57291a9443387c120e193573cf9c6f572d9855d55805fe4c284c36ff506L15-R16) [[6]](diffhunk://#diff-6ea6ddbf8d9714af08e85d0e86de8725168bb0494fa2122208d8865edc079c06L16-R17) [[7]](diffhunk://#diff-99c71695df4049665cec5f4e86d1ee55ff9c78b13458db4f985c8983bb080d23L11-R12) [[8]](diffhunk://#diff-f5c48c1decc6824377cc37f877dfe00fd154245350abda5333e5ebec8ed17b01L14-R15) [[9]](diffhunk://#diff-340a3a2854a6b04906db2a7f6174b4f8c76fc6dbc7a00615cd16c0df6dc7258dL12-R13) [[10]](diffhunk://#diff-9bb13879314ef0b59439dd0732605e86b8233f33a577937ebb779a7abaecceabL12-R13) [[11]](diffhunk://#diff-f0f778fafcd33bfed12c3b2f90540bf6821f150c44f61d471f2969ce373f1f69L10-R11) [[12]](diffhunk://#diff-64e4c0bbcb0474b58857aef090d6a43328f7bb3684814606a8ec4b4b80711d0cL12-R13) [[13]](diffhunk://#diff-a91bb387178218caf4438735124b0c6a98917516a42e2f2247055559a34c884dL14-R15) [[14]](diffhunk://#diff-79a7bc958fc73db5ebbc2d90f4c656ba172546e82099c4fe4080b8d3b67157d7L12-R13) [[15]](diffhunk://#diff-c16537df7ddc11777dd853f67f0814564304e0f98bcadc09e8cbdd9a489253e5L16-R17) [[16]](diffhunk://#diff-c904ae0292a30becd4b9f9492562a6215b2a6836f6743bb344c9dd82a3a3ae45L14-R15)

**Jaeger ingress configuration improvements:**

* Updated Jaeger addon ingress files for HAProxy, NGINX, and Traefik to use a nested `ingress` field with `hosts` and `ingressClassName`, aligning with best practices for custom resource definitions. [[1]](diffhunk://#diff-8c7b797139169e88fc70d03a03fb057ab20f13f1e146d516c626f7f0bc836dd8R7-R10) [[2]](diffhunk://#diff-10be26a0155059a35e5651c5fc1430e3fcc43e422d308c81b69d76f8fb681feeR7-R10) [[3]](diffhunk://#diff-16da836cda7483ef2e0868fe95e33f3b29b620679871cde6f07352f0386a6193R8-R11)

**Prometheus ingress fix:**

* Corrected the HAProxy Prometheus ingress to use the correct `ingressClassName`, path rewrite annotation, and added the explicit `host` field.