### PR TITLE
Update Kubernetes release selectors and CDN URLs

### DIFF
--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -105,7 +105,7 @@ fields:
           kubectl apply -f https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-crd.yaml
           curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://raw.githubusercontent.com/jelastic-jps/kubernetes/main/addons/open-liberty.yaml
+          kubectl apply -f https://raw.githubusercontent.com/xzkutor/kubernetes/main/addons/open-liberty.yaml
 
   - type: toggle
     name: storage

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -105,7 +105,7 @@ fields:
           kubectl apply -f https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-crd.yaml
           curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-rbac-watch-another.yaml | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -f -
           curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/0.8.2/kubectl/openliberty-app-operator.yaml | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${OPERATOR_NAMESPACE}/" | kubectl apply -n ${OPERATOR_NAMESPACE} -f -
-          kubectl apply -f https://raw.githubusercontent.com/xzkutor/kubernetes/main/addons/open-liberty.yaml
+          kubectl apply -f https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@main/addons/open-liberty.yaml
 
   - type: toggle
     name: storage

--- a/manifest.jps
+++ b/manifest.jps
@@ -21,17 +21,55 @@ onInstall:
 actions:
   check-version:
     - script: |
-        var baseUrl = "${baseUrl}".split("/"); baseUrl.pop(); baseUrl = baseUrl.join("/");
-        var url = baseUrl+"/${settings.version}/manifest.jps"
-        var huc = new java.net.URL(url).openConnection();
-        huc.setRequestMethod("HEAD");
-        var code = huc.getResponseCode();
-        if (code == 200){
-          return {result:0, onAfterReturn:{"install-cluster":{jps: url}}};
-        } else {
-          message = "The specified version ${settings.version} has no installation script!";
-          return {result:"", message: message};
+        function getStatusCode(url) {
+          try {
+            var connection = new java.net.URL(url).openConnection();
+            connection.setRequestMethod("HEAD");
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
+            return connection.getResponseCode();
+          } catch (e) {
+            return -1;
+          }
         }
+
+        var repositoryRoot = "${baseUrl}";
+        repositoryRoot = repositoryRoot.substring(0, repositoryRoot.lastIndexOf("/"));
+        var versionBaseUrl = repositoryRoot + "/${settings.version}";
+        var manifestUrl = versionBaseUrl + "/manifest.jps";
+        var manifestText = "";
+
+        try {
+          manifestText = String(new com.hivext.api.core.utils.Transport().get(manifestUrl));
+        } catch (e) {
+          manifestText = "";
+        }
+
+        if (!manifestText || manifestText.indexOf("baseUrl: " + versionBaseUrl) < 0) {
+          return {
+            result: "",
+            message: "The manifest for ${settings.version} is missing or points to a different baseUrl: " + manifestUrl
+          };
+        }
+
+        var requiredFiles = [
+          "/scripts/beforeinit.js",
+          "/scripts/beforeinstall.js",
+          "/configs/settings.yaml",
+          "/addons/upgrade.jps"
+        ];
+
+        for (var i = 0; i < requiredFiles.length; i++) {
+          var assetUrl = versionBaseUrl + requiredFiles[i];
+          if (getStatusCode(assetUrl) != 200) {
+            return {
+              result: "",
+              message: "The selected Kubernetes version has a missing asset: " + assetUrl
+            };
+          }
+        }
+
+        return {result: 0, onAfterReturn: {"install-cluster": {jps: manifestUrl}}};
 
   install-cluster:
     - params:

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes
-baseUrl: https://raw.githubusercontent.com/jelastic-jps/kubernetes/main
+baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/main
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 version: 1.5
 id: kubernetes
-baseUrl: https://raw.githubusercontent.com/xzkutor/kubernetes/main
+baseUrl: https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@main
 description:
   text: /text/description-kube.md
   short: Kubernetes cluster with automated scaling & cost efficient pay-per-use pricing for running cloud-native microservices.
@@ -33,9 +33,19 @@ actions:
           }
         }
 
-        var repositoryRoot = "${baseUrl}";
-        repositoryRoot = repositoryRoot.substring(0, repositoryRoot.lastIndexOf("/"));
-        var versionBaseUrl = repositoryRoot + "/${settings.version}";
+        function getVersionBaseUrl(baseUrl, version) {
+          var atIndex = baseUrl.lastIndexOf("@");
+          if (atIndex >= 0) {
+            var slashAfterRef = baseUrl.indexOf("/", atIndex);
+            if (slashAfterRef >= 0) {
+              return baseUrl.substring(0, atIndex + 1) + version + baseUrl.substring(slashAfterRef);
+            }
+            return baseUrl.substring(0, atIndex + 1) + version;
+          }
+          return baseUrl.substring(0, baseUrl.lastIndexOf("/")) + "/" + version;
+        }
+
+        var versionBaseUrl = getVersionBaseUrl("${baseUrl}", "${settings.version}");
         var manifestUrl = versionBaseUrl + "/manifest.jps";
         var manifestText = "";
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -79,12 +79,15 @@ var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/main/configs/set
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 
-let latestDefaultVersion = "v1.31.14";
+let latestDefaultVersion = "v1.34.8";
 
 if (${fn.compareEngine(8.3)} == 1) {
     f[0].items[0].default = latestDefaultVersion;
     f[0].items[0].values.push({ caption: "v1.29.14", value: "v1.29.14" });
     f[0].items[0].values.push({ caption: "v1.30.14", value: "v1.30.14" });
+    f[0].items[0].values.push({ caption: "v1.31.14", value: "v1.31.14" });
+    f[0].items[0].values.push({ caption: "v1.32.13", value: "v1.32.13" });
+    f[0].items[0].values.push({ caption: "v1.33.12", value: "v1.33.12" });
     f[0].items[0].values.push({ caption: latestDefaultVersion, value: latestDefaultVersion });
 }
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -79,12 +79,12 @@ var url = "https://raw.githubusercontent.com/jelastic-jps/kubernetes/main/config
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 
-let latestDefaultVersion = "v1.31.3";
+let latestDefaultVersion = "v1.31.14";
 
 if (${fn.compareEngine(8.3)} == 1) {
     f[0].items[0].default = latestDefaultVersion;
-    f[0].items[0].values.push({ caption: "v1.29.9", value: "v1.29.9" });
-    f[0].items[0].values.push({ caption: "v1.30.6", value: "v1.30.6" });
+    f[0].items[0].values.push({ caption: "v1.29.14", value: "v1.29.14" });
+    f[0].items[0].values.push({ caption: "v1.30.14", value: "v1.30.14" });
     f[0].items[0].values.push({ caption: latestDefaultVersion, value: latestDefaultVersion });
 }
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0, l = quotas.length; i < l; i++) {
     }
 }
 var resp = {result:0};
-var url = "https://raw.githubusercontent.com/jelastic-jps/kubernetes/main/configs/settings.yaml";
+var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/main/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -75,7 +75,7 @@ for (var i = 0, l = quotas.length; i < l; i++) {
     }
 }
 var resp = {result:0};
-var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/main/configs/settings.yaml";
+var url = "https://cdn.jsdelivr.net/gh/jelastic-jps/kubernetes@main/configs/settings.yaml";
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 

--- a/scripts/beforeinit.js
+++ b/scripts/beforeinit.js
@@ -79,7 +79,7 @@ var url = "https://raw.githubusercontent.com/xzkutor/kubernetes/main/configs/set
 resp.settings = toNative(new org.yaml.snakeyaml.Yaml().load(new com.hivext.api.core.utils.Transport().get(url)));
 var f = resp.settings.fields;
 
-let latestDefaultVersion = "v1.34.8";
+let latestDefaultVersion = "v1.35.6";
 
 if (${fn.compareEngine(8.3)} == 1) {
     f[0].items[0].default = latestDefaultVersion;
@@ -88,6 +88,7 @@ if (${fn.compareEngine(8.3)} == 1) {
     f[0].items[0].values.push({ caption: "v1.31.14", value: "v1.31.14" });
     f[0].items[0].values.push({ caption: "v1.32.13", value: "v1.32.13" });
     f[0].items[0].values.push({ caption: "v1.33.12", value: "v1.33.12" });
+    f[0].items[0].values.push({ caption: "v1.34.8", value: "v1.34.8" });
     f[0].items[0].values.push({ caption: latestDefaultVersion, value: latestDefaultVersion });
 }
 


### PR DESCRIPTION
This pull request updates the Kubernetes JPS (Jelastic Packaging Standard) manifest and related scripts to use the jsDelivr CDN for asset delivery instead of directly referencing raw GitHub URLs. It also enhances the version validation logic, updates the available Kubernetes versions, and ensures more robust asset checks during installation.

**Asset delivery and URL updates:**
* Changed all references from `raw.githubusercontent.com` to `cdn.jsdelivr.net/gh` for loading assets such as `settings.yaml` and `open-liberty.yaml`, improving reliability and performance. [[1]](diffhunk://#diff-86714dacb7653f97b688029cb0537acfa7284e7ba44394f1575ce3157c917668L4-R4) [[2]](diffhunk://#diff-342170a8dca5006e3e32fee642ab7faf6eb177b34a53cf2ea7e33d6ab986759bL78-R91) [[3]](diffhunk://#diff-7748ab1d47a9aff578cbd22d6343b7769ec34930fba42662161e6b5254cde161L108-R108)

**Version management and validation:**
* Updated the default Kubernetes version to `v1.35.6` and added newer versions (`v1.29.14`, `v1.30.14`, `v1.31.14`, `v1.32.13`, `v1.33.12`, `v1.34.8`) to the selectable list.
* Enhanced the version validation logic in the `onInstall` action to robustly check for the presence and correctness of required manifest assets, and to verify that the manifest’s `baseUrl` matches the expected URL for the selected version.

**Operator and addon deployment:**
* Updated the Open Liberty operator addon deployment to fetch the manifest from jsDelivr CDN, aligning with the new asset delivery approach.